### PR TITLE
Changing catalog URL doesn't work with existing DATA folder

### DIFF
--- a/manager/catalog_manager.go
+++ b/manager/catalog_manager.go
@@ -70,11 +70,15 @@ func SetEnv() {
 //Init clones or pulls the catalog, starts background refresh thread
 func Init() {
 	_, err := os.Stat(catalogRoot)
-	if err != nil {
-		cloneCatalog()
-	} else {
-		pullCatalog()
+	if err == nil {
+		//remove the existing repo
+		err := os.RemoveAll("./DATA/")
+		if err != nil {
+			log.Fatal("Cannot remove the existing catalog data folder ./DATA/", err)
+			_ = fmt.Errorf("Cannot remove the existing catalog data folder ./DATA/, error: " + err.Error())
+		}
 	}
+	cloneCatalog()
 	UUIDToPath = make(map[string]string)
 	Catalog = make(map[string]model.Template)
 	filepath.Walk(catalogRoot, walkCatalog)

--- a/model/rancher_compose.go
+++ b/model/rancher_compose.go
@@ -2,23 +2,25 @@ package model
 
 //import "github.com/rancher/rancher-compose/rancher"
 
+//Question holds the properties of a question present in rancher-compose.yml file
 type Question struct {
-	Variable	string 	 `json:"variable" yaml:"variable"`
-	Label       string   `json:"label" yaml:"label"`
-	Description string   `json:"description" yaml:"description"`
-	Type        string   `json:"type" yaml:"type"`
-	Required    bool     `json:"required" yaml:"required"`
-	Default     string   `json:"default" yaml:"default"`
-	Group       string   `json:"group" yaml:"group"`
-	MinLength   int      `json:"minLength" yaml:"minLength"`
-	MaxLength   int      `json:"maxLength" yaml:"maxLength"`
-	Min         int      `json:"min" yaml:"min"`
-	Max         int      `json:"max" yaml:"max"`
-	Options     []string `json:"options" yaml:"options"`
-	ValidChars  string   `json:"validChars" yaml:"validChars"`
-	InvalidChars string  `json:"invalidChars" yaml:"invalidChars"`
+	Variable     string   `json:"variable" yaml:"variable"`
+	Label        string   `json:"label" yaml:"label"`
+	Description  string   `json:"description" yaml:"description"`
+	Type         string   `json:"type" yaml:"type"`
+	Required     bool     `json:"required" yaml:"required"`
+	Default      string   `json:"default" yaml:"default"`
+	Group        string   `json:"group" yaml:"group"`
+	MinLength    int      `json:"minLength" yaml:"minLength"`
+	MaxLength    int      `json:"maxLength" yaml:"maxLength"`
+	Min          int      `json:"min" yaml:"min"`
+	Max          int      `json:"max" yaml:"max"`
+	Options      []string `json:"options" yaml:"options"`
+	ValidChars   string   `json:"validChars" yaml:"validChars"`
+	InvalidChars string   `json:"invalidChars" yaml:"invalidChars"`
 }
 
+//RancherCompose holds the questions array
 type RancherCompose struct {
 	//rancher.RancherConfig	`yaml:",inline"`
 	Questions []Question `json:"questions" yaml:"questions,omitempty"`

--- a/model/template.go
+++ b/model/template.go
@@ -2,10 +2,11 @@ package model
 
 import "github.com/rancher/go-rancher/client"
 
+//Template structure defines all properties that can be present in a template
 type Template struct {
 	client.Resource
 	Name           string            `json:"name"`
-	UUID 		   string			 `json:"uuid"`
+	UUID           string            `json:"uuid"`
 	Category       string            `json:"category"`
 	Description    string            `json:"description"`
 	Version        string            `json:"version"`
@@ -17,6 +18,7 @@ type Template struct {
 	Path           string            `json:"path"`
 }
 
+//TemplateCollection holds a collection of templates
 type TemplateCollection struct {
 	client.Collection
 	Data []Template `json:"data,omitempty"`

--- a/model/upgrade_info.go
+++ b/model/upgrade_info.go
@@ -2,8 +2,9 @@ package model
 
 import "github.com/rancher/go-rancher/client"
 
+//UpgradeInfo structure contains the new version info
 type UpgradeInfo struct {
 	client.Resource
-	CurrentVersion        string            `json:"currentVersion"`
-	NewVersionLinks       map[string]string `json:"newVersionLinks"`
+	CurrentVersion  string            `json:"currentVersion"`
+	NewVersionLinks map[string]string `json:"newVersionLinks"`
 }

--- a/scripts/all
+++ b/scripts/all
@@ -3,5 +3,5 @@ set -e
 
 ./scripts/build
 ./scripts/test
-#./scripts/validate
+./scripts/validate
 ./scripts/package

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 )
 
+//ListTemplates is a handler for route /templates and returns a collection of template metadata
 func ListTemplates(w http.ResponseWriter, r *http.Request) {
 	//read the catalog
 
@@ -28,6 +29,7 @@ func ListTemplates(w http.ResponseWriter, r *http.Request) {
 
 }
 
+//LoadTemplateMetadata returns template metadata for the provided templateId
 func LoadTemplateMetadata(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	path := vars["templateId"]
@@ -44,6 +46,7 @@ func LoadTemplateMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+//LoadTemplateVersion returns template version details for the provided templateId/versionId
 func LoadTemplateVersion(w http.ResponseWriter, r *http.Request) {
 	//read the template version from disk
 	vars := mux.Vars(r)
@@ -57,6 +60,7 @@ func LoadTemplateVersion(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(template)
 }
 
+//LoadImage returns template image
 func LoadImage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	path := "DATA/templates/" + vars["templateId"] + "/" + vars["versionId"] + "/" + vars["imageId"]
@@ -64,24 +68,26 @@ func LoadImage(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, path)
 }
 
+//RefreshCatalog will be doing a force catalog refresh
 func RefreshCatalog(w http.ResponseWriter, r *http.Request) {
 	log.Infof("Request to refresh catalog")
 	manager.RefreshCatalog()
 }
 
+//GetUpgradeInfo returns if any new versions are available for the given template uuid
 func GetUpgradeInfo(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	templateUUID := vars["templateUUID"]
 	log.Infof("Request to get new template versions for uuid %s", templateUUID)
-	
+
 	templateMetadata := manager.GetNewTemplateVersions(templateUUID)
 	if templateMetadata.Name != "" {
 		log.Debugf("Template returned by uuid: %v", templateMetadata.VersionLinks)
 		log.Debugf("Found Template: %s", templateMetadata.Name)
 		upgradeInfo := model.UpgradeInfo{}
 		upgradeInfo.CurrentVersion = templateMetadata.Version
-		
-		upgradeInfo.NewVersionLinks =  make(map[string]string) 
+
+		upgradeInfo.NewVersionLinks = make(map[string]string)
 		upgradeInfo.NewVersionLinks = PopulateTemplateLinks(r, &templateMetadata, "template")
 		//PopulateResource(r, "upgrade", templateMetadata.Name, &templateMetadata.Resource)
 		w.Header().Add("Content-Type", "application/json; charset=utf-8")
@@ -93,11 +99,13 @@ func GetUpgradeInfo(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+//PopulateCollection will populate any metadata for the resource collection
 func PopulateCollection(collection *client.Collection) {
 	collection.Type = "collection"
 	collection.ResourceType = "template"
 }
 
+//PopulateTemplateLinks will populate the links needed to load a template from the service
 func PopulateTemplateLinks(r *http.Request, template *model.Template, resourceType string) map[string]string {
 
 	copyOfversionLinks := make(map[string]string)
@@ -110,6 +118,7 @@ func PopulateTemplateLinks(r *http.Request, template *model.Template, resourceTy
 	return copyOfversionLinks
 }
 
+//PopulateResource will populate any metadata for the resource
 func PopulateResource(r *http.Request, resourceType, resourceID string, resource *client.Resource) {
 	resource.Type = resourceType
 
@@ -120,6 +129,7 @@ func PopulateResource(r *http.Request, resourceType, resourceID string, resource
 	}
 }
 
+//BuildURL will generate the links needed for template versions/resource self links
 func BuildURL(r *http.Request, resourceType, resourceID string) string {
 
 	var scheme = "http://"

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -19,7 +19,7 @@ func ListTemplates(w http.ResponseWriter, r *http.Request) {
 	for _, value := range manager.Catalog {
 		log.Debugf("Found Template: %s", value.Name)
 		value.VersionLinks = PopulateTemplateLinks(r, &value, "template")
-		PopulateResource(r, "template", value.Name, &value.Resource)
+		PopulateResource(r, "template", value.Path, &value.Resource)
 		resp.Data = append(resp.Data, value)
 	}
 
@@ -37,7 +37,7 @@ func LoadTemplateMetadata(w http.ResponseWriter, r *http.Request) {
 	templateMetadata, ok := manager.Catalog[path]
 	if ok {
 		templateMetadata.VersionLinks = PopulateTemplateLinks(r, &templateMetadata, "template")
-		PopulateResource(r, "template", templateMetadata.Name, &templateMetadata.Resource)
+		PopulateResource(r, "template", templateMetadata.Path, &templateMetadata.Resource)
 		w.Header().Add("Content-Type", "application/json; charset=utf-8")
 		json.NewEncoder(w).Encode(templateMetadata)
 	} else {

--- a/service/routes.go
+++ b/service/routes.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 )
 
+//Route defines the properties of a go mux http route
 type Route struct {
 	Name        string
 	Method      string
@@ -12,8 +13,10 @@ type Route struct {
 	HandlerFunc http.HandlerFunc
 }
 
+//Routes array of Route defined
 type Routes []Route
 
+//NewRouter creates and configures a mux router
 func NewRouter() *mux.Router {
 
 	router := mux.NewRouter().StrictSlash(true)


### PR DESCRIPTION
Fixes to remove existing catalog data, when a new catalogUrl is provided. Also fixed the 'self-link' of template metadata - the link should use the path property of a template and not the name.

https://github.com/rancher/rancher/issues/2354