### PR TITLE
Changes to remove config.yml file from template version folders and more

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,10 +9,12 @@ import (
 
 func main() {
 	log.Infof("Starting Rancher Catalog service")
-
-	manager.SetEnv()
-	manager.Init()
-
 	router := service.NewRouter()
-	log.Fatal(http.ListenAndServe(":8088", router))
+	handler := service.MuxWrapper{false, router}
+
+	go func() {
+		manager.SetEnv()
+		manager.Init()
+	}()
+	log.Fatal(http.ListenAndServe(":8088", &handler))
 }

--- a/model/rancher_compose.go
+++ b/model/rancher_compose.go
@@ -4,24 +4,28 @@ package model
 
 //Question holds the properties of a question present in rancher-compose.yml file
 type Question struct {
-	Variable     string   `json:"variable" yaml:"variable"`
-	Label        string   `json:"label" yaml:"label"`
-	Description  string   `json:"description" yaml:"description"`
-	Type         string   `json:"type" yaml:"type"`
-	Required     bool     `json:"required" yaml:"required"`
-	Default      string   `json:"default" yaml:"default"`
-	Group        string   `json:"group" yaml:"group"`
-	MinLength    int      `json:"minLength" yaml:"minLength"`
-	MaxLength    int      `json:"maxLength" yaml:"maxLength"`
-	Min          int      `json:"min" yaml:"min"`
-	Max          int      `json:"max" yaml:"max"`
-	Options      []string `json:"options" yaml:"options"`
-	ValidChars   string   `json:"validChars" yaml:"validChars"`
-	InvalidChars string   `json:"invalidChars" yaml:"invalidChars"`
+	Variable     string   `json:"variable" yaml:"variable,omitempty"`
+	Label        string   `json:"label" yaml:"label,omitempty"`
+	Description  string   `json:"description" yaml:"description,omitempty"`
+	Type         string   `json:"type" yaml:"type,omitempty"`
+	Required     bool     `json:"required" yaml:"required,omitempty"`
+	Default      string   `json:"default" yaml:"default,omitempty"`
+	Group        string   `json:"group" yaml:"group,omitempty"`
+	MinLength    int      `json:"minLength" yaml:"min_length,omitempty"`
+	MaxLength    int      `json:"maxLength" yaml:"max_length,omitempty"`
+	Min          int      `json:"min" yaml:"min,omitempty"`
+	Max          int      `json:"max" yaml:"max,omitempty"`
+	Options      []string `json:"options" yaml:"options,omitempty"`
+	ValidChars   string   `json:"validChars" yaml:"valid_chars,omitempty"`
+	InvalidChars string   `json:"invalidChars" yaml:"invalid_chars,omitempty"`
 }
 
 //RancherCompose holds the questions array
 type RancherCompose struct {
 	//rancher.RancherConfig	`yaml:",inline"`
-	Questions []Question `json:"questions" yaml:"questions,omitempty"`
+	Name        string     `yaml:"name"`
+	UUID        string     `yaml:"uuid"`
+	Description string     `yaml:"description"`
+	Version     string     `yaml:"version"`
+	Questions   []Question `json:"questions" yaml:"questions,omitempty"`
 }


### PR DESCRIPTION
Changes include: 
- Remove config.yml file from template version folders. 
- Also Service will now listen at start and retrun 503 until the catalog is ready. 
- Also log the git clone output.
- Correct the yaml fields to be underscore lowercase separated