### PR TITLE
Support for minimumRancherVersion property on templates and added a filter minimumRancherVersion_lte

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -8,6 +8,10 @@
 			"Rev": "26709e2714106fb8ad40b773b711ebce25b78914"
 		},
 		{
+			"ImportPath": "github.com/coreos/go-semver/semver",
+			"Rev": "d043ae190b3202550d026daf009359bb5d761672"
+		},
+		{
 			"ImportPath": "github.com/gorilla/context",
 			"Rev": "215affda49addc4c8ef7e2534915df2c8c35c6cd"
 		},

--- a/Godeps/_workspace/src/github.com/coreos/go-semver/semver/semver.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-semver/semver/semver.go
@@ -1,0 +1,244 @@
+// Copyright 2013-2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Semantic Versions http://semver.org
+package semver
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Version struct {
+	Major      int64
+	Minor      int64
+	Patch      int64
+	PreRelease PreRelease
+	Metadata   string
+}
+
+type PreRelease string
+
+func splitOff(input *string, delim string) (val string) {
+	parts := strings.SplitN(*input, delim, 2)
+
+	if len(parts) == 2 {
+		*input = parts[0]
+		val = parts[1]
+	}
+
+	return val
+}
+
+func NewVersion(version string) (*Version, error) {
+	v := Version{}
+
+	v.Metadata = splitOff(&version, "+")
+	v.PreRelease = PreRelease(splitOff(&version, "-"))
+
+	dotParts := strings.SplitN(version, ".", 3)
+
+	if len(dotParts) != 3 {
+		return nil, errors.New(fmt.Sprintf("%s is not in dotted-tri format", version))
+	}
+
+	parsed := make([]int64, 3, 3)
+
+	for i, v := range dotParts[:3] {
+		val, err := strconv.ParseInt(v, 10, 64)
+		parsed[i] = val
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	v.Major = parsed[0]
+	v.Minor = parsed[1]
+	v.Patch = parsed[2]
+
+	return &v, nil
+}
+
+func Must(v *Version, err error) *Version {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func (v *Version) String() string {
+	var buffer bytes.Buffer
+
+	fmt.Fprintf(&buffer, "%d.%d.%d", v.Major, v.Minor, v.Patch)
+
+	if v.PreRelease != "" {
+		fmt.Fprintf(&buffer, "-%s", v.PreRelease)
+	}
+
+	if v.Metadata != "" {
+		fmt.Fprintf(&buffer, "+%s", v.Metadata)
+	}
+
+	return buffer.String()
+}
+
+func (v *Version) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + v.String() + `"`), nil
+}
+
+func (v *Version) UnmarshalJSON(data []byte) error {
+	l := len(data)
+	if l == 0 || string(data) == `""` {
+		return nil
+	}
+	if l < 2 || data[0] != '"' || data[l-1] != '"' {
+		return errors.New("invalid semver string")
+	}
+	vv, err := NewVersion(string(data[1 : l-1]))
+	if err != nil {
+		return err
+	}
+	*v = *vv
+	return nil
+}
+
+func (v *Version) LessThan(versionB Version) bool {
+	versionA := *v
+	cmp := recursiveCompare(versionA.Slice(), versionB.Slice())
+
+	if cmp == 0 {
+		cmp = preReleaseCompare(versionA, versionB)
+	}
+
+	if cmp == -1 {
+		return true
+	}
+
+	return false
+}
+
+/* Slice converts the comparable parts of the semver into a slice of strings */
+func (v *Version) Slice() []int64 {
+	return []int64{v.Major, v.Minor, v.Patch}
+}
+
+func (p *PreRelease) Slice() []string {
+	preRelease := string(*p)
+	return strings.Split(preRelease, ".")
+}
+
+func preReleaseCompare(versionA Version, versionB Version) int {
+	a := versionA.PreRelease
+	b := versionB.PreRelease
+
+	/* Handle the case where if two versions are otherwise equal it is the
+	 * one without a PreRelease that is greater */
+	if len(a) == 0 && (len(b) > 0) {
+		return 1
+	} else if len(b) == 0 && (len(a) > 0) {
+		return -1
+	}
+
+	// If there is a prelease, check and compare each part.
+	return recursivePreReleaseCompare(a.Slice(), b.Slice())
+}
+
+func recursiveCompare(versionA []int64, versionB []int64) int {
+	if len(versionA) == 0 {
+		return 0
+	}
+
+	a := versionA[0]
+	b := versionB[0]
+
+	if a > b {
+		return 1
+	} else if a < b {
+		return -1
+	}
+
+	return recursiveCompare(versionA[1:], versionB[1:])
+}
+
+func recursivePreReleaseCompare(versionA []string, versionB []string) int {
+	// Handle slice length disparity.
+	if len(versionA) == 0 {
+		// Nothing to compare too, so we return 0
+		return 0
+	} else if len(versionB) == 0 {
+		// We're longer than versionB so return 1.
+		return 1
+	}
+
+	a := versionA[0]
+	b := versionB[0]
+
+	aInt := false
+	bInt := false
+
+	aI, err := strconv.Atoi(versionA[0])
+	if err == nil {
+		aInt = true
+	}
+
+	bI, err := strconv.Atoi(versionB[0])
+	if err == nil {
+		bInt = true
+	}
+
+	// Handle Integer Comparison
+	if aInt && bInt {
+		if aI > bI {
+			return 1
+		} else if aI < bI {
+			return -1
+		}
+	}
+
+	// Handle String Comparison
+	if a > b {
+		return 1
+	} else if a < b {
+		return -1
+	}
+
+	return recursivePreReleaseCompare(versionA[1:], versionB[1:])
+}
+
+// BumpMajor increments the Major field by 1 and resets all other fields to their default values
+func (v *Version) BumpMajor() {
+	v.Major += 1
+	v.Minor = 0
+	v.Patch = 0
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}
+
+// BumpMinor increments the Minor field by 1 and resets all other fields to their default values
+func (v *Version) BumpMinor() {
+	v.Minor += 1
+	v.Patch = 0
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}
+
+// BumpPatch increments the Patch field by 1 and resets all other fields to their default values
+func (v *Version) BumpPatch() {
+	v.Patch += 1
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}

--- a/Godeps/_workspace/src/github.com/coreos/go-semver/semver/semver_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-semver/semver/semver_test.go
@@ -1,0 +1,297 @@
+// Copyright 2013-2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semver
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"math/rand"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type fixture struct {
+	GreaterVersion string
+	LesserVersion  string
+}
+
+var fixtures = []fixture{
+	fixture{"0.0.0", "0.0.0-foo"},
+	fixture{"0.0.1", "0.0.0"},
+	fixture{"1.0.0", "0.9.9"},
+	fixture{"0.10.0", "0.9.0"},
+	fixture{"0.99.0", "0.10.0"},
+	fixture{"2.0.0", "1.2.3"},
+	fixture{"0.0.0", "0.0.0-foo"},
+	fixture{"0.0.1", "0.0.0"},
+	fixture{"1.0.0", "0.9.9"},
+	fixture{"0.10.0", "0.9.0"},
+	fixture{"0.99.0", "0.10.0"},
+	fixture{"2.0.0", "1.2.3"},
+	fixture{"0.0.0", "0.0.0-foo"},
+	fixture{"0.0.1", "0.0.0"},
+	fixture{"1.0.0", "0.9.9"},
+	fixture{"0.10.0", "0.9.0"},
+	fixture{"0.99.0", "0.10.0"},
+	fixture{"2.0.0", "1.2.3"},
+	fixture{"1.2.3", "1.2.3-asdf"},
+	fixture{"1.2.3", "1.2.3-4"},
+	fixture{"1.2.3", "1.2.3-4-foo"},
+	fixture{"1.2.3-5-foo", "1.2.3-5"},
+	fixture{"1.2.3-5", "1.2.3-4"},
+	fixture{"1.2.3-5-foo", "1.2.3-5-Foo"},
+	fixture{"3.0.0", "2.7.2+asdf"},
+	fixture{"3.0.0+foobar", "2.7.2"},
+	fixture{"1.2.3-a.10", "1.2.3-a.5"},
+	fixture{"1.2.3-a.b", "1.2.3-a.5"},
+	fixture{"1.2.3-a.b", "1.2.3-a"},
+	fixture{"1.2.3-a.b.c.10.d.5", "1.2.3-a.b.c.5.d.100"},
+	fixture{"1.0.0", "1.0.0-rc.1"},
+	fixture{"1.0.0-rc.2", "1.0.0-rc.1"},
+	fixture{"1.0.0-rc.1", "1.0.0-beta.11"},
+	fixture{"1.0.0-beta.11", "1.0.0-beta.2"},
+	fixture{"1.0.0-beta.2", "1.0.0-beta"},
+	fixture{"1.0.0-beta", "1.0.0-alpha.beta"},
+	fixture{"1.0.0-alpha.beta", "1.0.0-alpha.1"},
+	fixture{"1.0.0-alpha.1", "1.0.0-alpha"},
+}
+
+func TestCompare(t *testing.T) {
+	for _, v := range fixtures {
+		gt, err := NewVersion(v.GreaterVersion)
+		if err != nil {
+			t.Error(err)
+		}
+
+		lt, err := NewVersion(v.LesserVersion)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if gt.LessThan(*lt) == true {
+			t.Errorf("%s should not be less than %s", gt, lt)
+		}
+	}
+}
+
+func testString(t *testing.T, orig string, version *Version) {
+	if orig != version.String() {
+		t.Errorf("%s != %s", orig, version)
+	}
+}
+
+func TestString(t *testing.T) {
+	for _, v := range fixtures {
+		gt, err := NewVersion(v.GreaterVersion)
+		if err != nil {
+			t.Error(err)
+		}
+		testString(t, v.GreaterVersion, gt)
+
+		lt, err := NewVersion(v.LesserVersion)
+		if err != nil {
+			t.Error(err)
+		}
+		testString(t, v.LesserVersion, lt)
+	}
+}
+
+func shuffleStringSlice(src []string) []string {
+	dest := make([]string, len(src))
+	rand.Seed(time.Now().Unix())
+	perm := rand.Perm(len(src))
+	for i, v := range perm {
+		dest[v] = src[i]
+	}
+	return dest
+}
+
+func TestSort(t *testing.T) {
+	sortedVersions := []string{"1.0.0", "1.0.2", "1.2.0", "3.1.1"}
+	unsortedVersions := shuffleStringSlice(sortedVersions)
+
+	semvers := []*Version{}
+	for _, v := range unsortedVersions {
+		sv, err := NewVersion(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		semvers = append(semvers, sv)
+	}
+
+	Sort(semvers)
+
+	for idx, sv := range semvers {
+		if sv.String() != sortedVersions[idx] {
+			t.Fatalf("incorrect sort at index %v", idx)
+		}
+	}
+}
+
+func TestBumpMajor(t *testing.T) {
+	version, _ := NewVersion("1.0.0")
+	version.BumpMajor()
+	if version.Major != 2 {
+		t.Fatalf("bumping major on 1.0.0 resulted in %v", version)
+	}
+
+	version, _ = NewVersion("1.5.2")
+	version.BumpMajor()
+	if version.Minor != 0 && version.Patch != 0 {
+		t.Fatalf("bumping major on 1.5.2 resulted in %v", version)
+	}
+
+	version, _ = NewVersion("1.0.0+build.1-alpha.1")
+	version.BumpMajor()
+	if version.PreRelease != "" && version.PreRelease != "" {
+		t.Fatalf("bumping major on 1.0.0+build.1-alpha.1 resulted in %v", version)
+	}
+}
+
+func TestBumpMinor(t *testing.T) {
+	version, _ := NewVersion("1.0.0")
+	version.BumpMinor()
+
+	if version.Major != 1 {
+		t.Fatalf("bumping minor on 1.0.0 resulted in %v", version)
+	}
+
+	if version.Minor != 1 {
+		t.Fatalf("bumping major on 1.0.0 resulted in %v", version)
+	}
+
+	version, _ = NewVersion("1.0.0+build.1-alpha.1")
+	version.BumpMinor()
+	if version.PreRelease != "" && version.PreRelease != "" {
+		t.Fatalf("bumping major on 1.0.0+build.1-alpha.1 resulted in %v", version)
+	}
+}
+
+func TestBumpPatch(t *testing.T) {
+	version, _ := NewVersion("1.0.0")
+	version.BumpPatch()
+
+	if version.Major != 1 {
+		t.Fatalf("bumping minor on 1.0.0 resulted in %v", version)
+	}
+
+	if version.Minor != 0 {
+		t.Fatalf("bumping major on 1.0.0 resulted in %v", version)
+	}
+
+	if version.Patch != 1 {
+		t.Fatalf("bumping major on 1.0.0 resulted in %v", version)
+	}
+
+	version, _ = NewVersion("1.0.0+build.1-alpha.1")
+	version.BumpPatch()
+	if version.PreRelease != "" && version.PreRelease != "" {
+		t.Fatalf("bumping major on 1.0.0+build.1-alpha.1 resulted in %v", version)
+	}
+}
+
+func TestMust(t *testing.T) {
+	tests := []struct {
+		versionStr string
+
+		version *Version
+		recov   interface{}
+	}{
+		{
+			versionStr: "1.0.0",
+			version:    &Version{Major: 1},
+		},
+		{
+			versionStr: "version number",
+			recov:      errors.New("version number is not in dotted-tri format"),
+		},
+	}
+
+	for _, tt := range tests {
+		func() {
+			defer func() {
+				recov := recover()
+				if !reflect.DeepEqual(tt.recov, recov) {
+					t.Fatalf("incorrect panic for %q: want %v, got %v", tt.versionStr, tt.recov, recov)
+				}
+			}()
+
+			version := Must(NewVersion(tt.versionStr))
+			if !reflect.DeepEqual(tt.version, version) {
+				t.Fatalf("incorrect version for %q: want %+v, got %+v", tt.versionStr, tt.version, version)
+			}
+		}()
+	}
+}
+
+type fixtureJSON struct {
+	GreaterVersion *Version
+	LesserVersion  *Version
+}
+
+func TestJSON(t *testing.T) {
+	fj := make([]fixtureJSON, len(fixtures))
+	for i, v := range fixtures {
+		var err error
+		fj[i].GreaterVersion, err = NewVersion(v.GreaterVersion)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fj[i].LesserVersion, err = NewVersion(v.LesserVersion)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fromStrings, err := json.Marshal(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fromVersions, err := json.Marshal(fj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(fromStrings, fromVersions) {
+		t.Errorf("Expected:   %s", fromStrings)
+		t.Errorf("Unexpected: %s", fromVersions)
+	}
+
+	fromJson := make([]fixtureJSON, 0, len(fj))
+	err = json.Unmarshal(fromStrings, &fromJson)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(fromJson, fj) {
+		t.Error("Expected:   ", fj)
+		t.Error("Unexpected: ", fromJson)
+	}
+}
+
+func TestBadInput(t *testing.T) {
+	bad := []string{
+		"1.2",
+		"1.2.3x",
+		"0x1.3.4",
+		"-1.2.3",
+		"1.2.3.4",
+	}
+	for _, b := range bad {
+		if _, err := NewVersion(b); err == nil {
+			t.Error("Improperly accepted value: ", b)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/coreos/go-semver/semver/sort.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-semver/semver/sort.go
@@ -1,0 +1,38 @@
+// Copyright 2013-2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semver
+
+import (
+	"sort"
+)
+
+type Versions []*Version
+
+func (s Versions) Len() int {
+	return len(s)
+}
+
+func (s Versions) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s Versions) Less(i, j int) bool {
+	return s[i].LessThan(*s[j])
+}
+
+// Sort sorts the given slice of Version
+func Sort(versions []*Version) {
+	sort.Sort(Versions(versions))
+}

--- a/model/rancher_compose.go
+++ b/model/rancher_compose.go
@@ -23,9 +23,10 @@ type Question struct {
 //RancherCompose holds the questions array
 type RancherCompose struct {
 	//rancher.RancherConfig	`yaml:",inline"`
-	Name        string     `yaml:"name"`
-	UUID        string     `yaml:"uuid"`
-	Description string     `yaml:"description"`
-	Version     string     `yaml:"version"`
-	Questions   []Question `json:"questions" yaml:"questions,omitempty"`
+	Name                  string     `yaml:"name"`
+	UUID                  string     `yaml:"uuid"`
+	Description           string     `yaml:"description"`
+	Version               string     `yaml:"version"`
+	Questions             []Question `json:"questions" yaml:"questions,omitempty"`
+	MinimumRancherVersion string     `json:"minimumRancherVersion" yaml:"minimum_rancher_version,omitempty"`
 }

--- a/model/template.go
+++ b/model/template.go
@@ -5,17 +5,19 @@ import "github.com/rancher/go-rancher/client"
 //Template structure defines all properties that can be present in a template
 type Template struct {
 	client.Resource
-	Name           string            `json:"name"`
-	UUID           string            `json:"uuid"`
-	Category       string            `json:"category"`
-	Description    string            `json:"description"`
-	Version        string            `json:"version"`
-	IconLink       string            `json:"iconLink"`
-	VersionLinks   map[string]string `json:"versionLinks"`
-	DockerCompose  string            `json:"dockerCompose"`
-	RancherCompose string            `json:"rancherCompose"`
-	Questions      []Question        `json:"questions"`
-	Path           string            `json:"path"`
+	Name                          string            `json:"name"`
+	UUID                          string            `json:"uuid"`
+	Category                      string            `json:"category"`
+	Description                   string            `json:"description"`
+	Version                       string            `json:"version"`
+	IconLink                      string            `json:"iconLink"`
+	VersionLinks                  map[string]string `json:"versionLinks"`
+	DockerCompose                 string            `json:"dockerCompose"`
+	RancherCompose                string            `json:"rancherCompose"`
+	Questions                     []Question        `json:"questions"`
+	Path                          string            `json:"path"`
+	MinimumRancherVersion         string            `json:"minimumRancherVersion"`
+	TemplateVersionRancherVersion map[string]string
 }
 
 //TemplateCollection holds a collection of templates


### PR DESCRIPTION
Added support for property 'minimumRancherVersion' on the templates .catalog section
Added a filter on the api:  /v1-catalog/templates?minimumRancherVersion_lte=<version>

Fixes https://github.com/rancher/rancher/issues/2489




