### PR TITLE
Additional config fields added 

### DIFF
--- a/model/rancher_compose.go
+++ b/model/rancher_compose.go
@@ -20,6 +20,11 @@ type Question struct {
 	InvalidChars string   `json:"invalidChars" yaml:"invalid_chars,omitempty"`
 }
 
+//Output holds the outputs of the template
+type Output struct {
+	URL string `json:"url" yaml:"url,omitempty"`
+}
+
 //RancherCompose holds the questions array
 type RancherCompose struct {
 	//rancher.RancherConfig	`yaml:",inline"`
@@ -29,4 +34,5 @@ type RancherCompose struct {
 	Version               string     `yaml:"version"`
 	Questions             []Question `json:"questions" yaml:"questions,omitempty"`
 	MinimumRancherVersion string     `json:"minimumRancherVersion" yaml:"minimum_rancher_version,omitempty"`
+	Output                Output     `json:"output" yaml:"output,omitempty"`
 }

--- a/model/template.go
+++ b/model/template.go
@@ -18,6 +18,11 @@ type Template struct {
 	Path                          string            `json:"path"`
 	MinimumRancherVersion         string            `json:"minimumRancherVersion"`
 	TemplateVersionRancherVersion map[string]string
+	Maintainer                    string `json:"maintainer"`
+	License                       string `json:"license"`
+	ProjectURL                    string `json:"projectURL"`
+	ReadmeLink                    string `json:"readmeLink"`
+	Output                        Output `json:"output" yaml:"output,omitempty"`
 }
 
 //TemplateCollection holds a collection of templates

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -126,6 +126,14 @@ func LoadImage(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, path)
 }
 
+//LoadFile returns template image
+func LoadFile(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	path := "DATA/templates/" + vars["templateId"] + "/" + vars["versionId"] + "/" + vars["fileId"]
+	log.Debugf("Request to load file: %s", path)
+	http.ServeFile(w, r, path)
+}
+
 //RefreshCatalog will be doing a force catalog refresh
 func RefreshCatalog(w http.ResponseWriter, r *http.Request) {
 	log.Infof("Request to refresh catalog")
@@ -172,6 +180,9 @@ func PopulateTemplateLinks(r *http.Request, template *model.Template, resourceTy
 	}
 
 	template.IconLink = BuildURL(r, "image", template.IconLink)
+	if template.ReadmeLink != "" {
+		template.ReadmeLink = BuildURL(r, "file", template.ReadmeLink)
+	}
 
 	return copyOfversionLinks
 }

--- a/service/routes.go
+++ b/service/routes.go
@@ -92,6 +92,18 @@ var routes = Routes{
 		LoadImage,
 	},
 	Route{
+		"LoadVersionFile",
+		"GET",
+		"/v1-catalog/files/{templateId}/{versionId}/{fileId}",
+		LoadFile,
+	},
+	Route{
+		"LoadFile",
+		"GET",
+		"/v1-catalog/files/{templateId}/{fileId}",
+		LoadFile,
+	},
+	Route{
 		"RefreshCatalog",
 		"POST",
 		"/v1-catalog/templates",


### PR DESCRIPTION
Changes to support:
1) Additional fields to config.yml [maintainer, license, projectURL] 
2) readme.md file under each template, a link will be provided in the response
3) output section in .catalog section of templates

https://github.com/rancher/rancher/issues/2643