### PR TITLE
Support for multiple catalog repos.

### DIFF
--- a/manager/catalog.go
+++ b/manager/catalog.go
@@ -1,0 +1,275 @@
+package manager
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/rancher/go-rancher/client"
+	"github.com/rancher/rancher-catalog-service/model"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var (
+	metadataFolder = regexp.MustCompile(`^DATA/[^/]+/templates/[^/]+$`)
+)
+
+//CatalogCollection holds a collection of catalogs
+type CatalogCollection struct {
+	client.Collection
+	Data []Catalog `json:"data,omitempty"`
+}
+
+//Catalog defines the properties of a template Catalog
+type Catalog struct {
+	client.Resource
+	CatalogID         string `json:"id"`
+	Description       string
+	CatalogLink       string `json:"catalogLink"`
+	url               string
+	catalogRoot       string
+	refreshReqChannel *chan int
+	metadata          map[string]model.Template
+}
+
+func (cat *Catalog) getID() string {
+	return cat.CatalogID
+}
+
+func (cat *Catalog) cloneCatalog() {
+	log.Infof("Cloning the catalog from git url %s", cat.url)
+	//git clone the repo
+	e := exec.Command("git", "clone", cat.url, cat.catalogRoot)
+	e.Stdout = os.Stdout
+	e.Stderr = os.Stderr
+	err := e.Run()
+	if err != nil {
+		log.Fatalf("Failed to clone the catalog from github %v", err.Error())
+	}
+	cat.metadata = make(map[string]model.Template)
+	//walk the catalog and read the metadata to the cache
+	filepath.Walk(cat.catalogRoot, cat.walkCatalog)
+}
+
+func (cat *Catalog) walkCatalog(path string, f os.FileInfo, err error) error {
+	//log.Debugf("Reading folder for template:%s %v", path, f)
+
+	if f != nil && f.IsDir() && metadataFolder.MatchString(path) {
+
+		log.Debugf("Reading metadata folder for template:%s, path: %v", f.Name(), path)
+		newTemplate := model.Template{
+			Resource: client.Resource{
+				Id:   f.Name(),
+				Type: "template",
+			},
+			Path: cat.CatalogID + "/" + f.Name(), //catalogRoot + f.Name()
+		}
+
+		//read the root level config.yml
+		readTemplateConfig(path, &newTemplate)
+
+		//list the folders under the root level
+		newTemplate.VersionLinks = make(map[string]string)
+		newTemplate.TemplateVersionRancherVersion = make(map[string]string)
+		dirList, err := ioutil.ReadDir(path)
+		if err != nil {
+			log.Errorf("Error reading directories at path: %s, error: %v", f.Name(), err)
+		} else {
+			for _, subfile := range dirList {
+				if subfile.IsDir() {
+					//read the subversion config.yml file into a template
+					subTemplate := model.Template{}
+					err := readRancherCompose(path+"/"+subfile.Name(), &subTemplate)
+					if err == nil {
+						if subTemplate.UUID != "" {
+							UUIDToPath[subTemplate.UUID] = newTemplate.Path + "/" + subfile.Name()
+							log.Debugf("UUIDToPath map: %v", UUIDToPath)
+						}
+						newTemplate.VersionLinks[subTemplate.Version] = newTemplate.Path + "/" + subfile.Name()
+						newTemplate.TemplateVersionRancherVersion[subTemplate.Version] = subTemplate.MinimumRancherVersion
+					} else {
+						log.Errorf("Skipping the template version: %s, error: %v", f.Name()+"/"+subfile.Name(), err)
+					}
+				} else if strings.HasPrefix(subfile.Name(), "catalogIcon") {
+					newTemplate.IconLink = newTemplate.Path + "/" + subfile.Name()
+				} else if strings.HasPrefix(strings.ToLower(subfile.Name()), "readme") {
+					newTemplate.ReadmeLink = newTemplate.Path + "/" + subfile.Name()
+				}
+			}
+		}
+
+		cat.metadata[newTemplate.Path] = newTemplate
+	}
+
+	return nil
+}
+
+func (cat *Catalog) pullCatalog() error {
+	log.Infof("Pulling the catalog %s from the repo to sync any new changes to %s", cat.CatalogID, cat.catalogRoot)
+
+	e := exec.Command("git", "-C", cat.catalogRoot, "pull", "-r", "origin", "master")
+
+	err := e.Run()
+	if err != nil {
+		log.Errorf("Failed to pull the catalog from github repo %s, error: %v", cat.url, err.Error())
+		return err
+	}
+	return nil
+}
+
+func (cat *Catalog) refreshCatalog() {
+	//put msg on channel, so that any other request can wait
+	select {
+	case *cat.refreshReqChannel <- 1:
+		err := cat.pullCatalog()
+		if err == nil {
+			log.Debug("Refreshing the catalog %s ...", cat.getID())
+			//walk the catalog and read the metadata to the cache
+			cat.metadata = make(map[string]model.Template)
+			filepath.Walk(cat.catalogRoot, cat.walkCatalog)
+		} else {
+			log.Debugf("Will not refresh the catalog since Pull Catalog faced error: %v", err)
+		}
+		<-*cat.refreshReqChannel
+	default:
+		log.Infof("Refresh for this catalog %s is already in process, skipping", cat.getID())
+	}
+}
+
+func readTemplateConfig(relativePath string, template *model.Template) {
+	filename, err := filepath.Abs(relativePath + "/config.yml")
+	if err != nil {
+		log.Errorf("Error forming path to config file at path: %s, error: %v", relativePath, err)
+	}
+
+	yamlFile, err := ioutil.ReadFile(filename)
+	if err != nil {
+		log.Errorf("Error reading config file under template: %s, error: %v", relativePath, err)
+	} else {
+		config := make(map[string]string)
+
+		//Read the config.yml file
+		err = yaml.Unmarshal(yamlFile, &config)
+		if err != nil {
+			log.Errorf("Error unmarshalling config.yml under template: %s, error: %v", relativePath, err)
+		} else {
+			template.Name = config["name"]
+			template.Category = config["category"]
+			template.Description = config["description"]
+			template.Version = config["version"]
+			if config["uuid"] != "" {
+				template.UUID = config["uuid"]
+			}
+			template.Maintainer = config["maintainer"]
+			template.License = config["license"]
+			template.ProjectURL = config["projectURL"]
+		}
+	}
+}
+
+func readRancherCompose(relativePath string, newTemplate *model.Template) error {
+
+	composeBytes := readFile(relativePath, "rancher-compose.yml")
+	newTemplate.RancherCompose = string(*composeBytes)
+
+	//read the questions section
+	RC := make(map[string]model.RancherCompose)
+	err := yaml.Unmarshal(*composeBytes, &RC)
+	if err != nil {
+		log.Errorf("Error unmarshalling %s under template: %s, error: %v", "rancher-compose.yml", relativePath, err)
+		return err
+	}
+	newTemplate.Questions = RC[".catalog"].Questions
+	newTemplate.Name = RC[".catalog"].Name
+	newTemplate.UUID = RC[".catalog"].UUID
+	newTemplate.Description = RC[".catalog"].Description
+	newTemplate.Version = RC[".catalog"].Version
+	newTemplate.MinimumRancherVersion = RC[".catalog"].MinimumRancherVersion
+	newTemplate.Output = RC[".catalog"].Output
+
+	/*if newTemplate.UUID != "" {
+		//store uuid -> path map
+		UUIDToPath[newTemplate.UUID] = relativePath
+		log.Debugf("UUIDToPath map: %v", UUIDToPath)
+	}*/
+	return nil
+}
+
+func readFile(relativePath string, fileName string) *[]byte {
+	filename, err := filepath.Abs(relativePath + "/" + fileName)
+	if err != nil {
+		log.Errorf("Error forming path to file %s, error: %v", relativePath+"/"+fileName, err)
+	}
+
+	composeBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		log.Errorf("Error reading file %s, error: %v", relativePath+"/"+fileName, err)
+		return nil
+	}
+	return &composeBytes
+}
+
+//ReadTemplateVersion reads the template version details
+func (cat *Catalog) ReadTemplateVersion(templateID string, versionID string) (*model.Template, bool) {
+
+	path := cat.CatalogID + "/templates/" + templateID + "/" + versionID
+	dirList, err := ioutil.ReadDir(CatalogRootDir + path)
+	newTemplate := model.Template{}
+	newTemplate.Path = cat.CatalogID + "/" + templateID + "/" + versionID
+	newTemplate.Id = cat.CatalogID + ":" + templateID + ":" + versionID
+
+	if err != nil {
+		log.Errorf("Error reading template at path: %s, error: %v", path, err)
+		return nil, false
+	}
+
+	var foundIcon, foundReadme bool
+
+	for _, subfile := range dirList {
+		if strings.HasPrefix(subfile.Name(), "catalogIcon") {
+
+			newTemplate.IconLink = newTemplate.Path + "/" + subfile.Name()
+			foundIcon = true
+
+		} else if strings.HasPrefix(subfile.Name(), "docker-compose") {
+
+			newTemplate.DockerCompose = string(*(readFile(CatalogRootDir+path, subfile.Name())))
+
+		} else if strings.HasPrefix(subfile.Name(), "rancher-compose") {
+
+			readRancherCompose(CatalogRootDir+path, &newTemplate)
+		} else if strings.HasPrefix(strings.ToLower(subfile.Name()), "readme") {
+
+			newTemplate.ReadmeLink = newTemplate.Path + "/" + subfile.Name()
+			foundReadme = true
+
+		}
+	}
+	if !foundIcon {
+		//use the parent icon
+		parentPath := cat.CatalogID + "/" + templateID
+		parentMetadata, ok := cat.metadata[parentPath]
+		if ok {
+			newTemplate.IconLink = parentMetadata.IconLink
+		} else {
+			log.Debugf("Could not find the parent metadata %s", parentPath)
+		}
+	}
+
+	if !foundReadme {
+		//use the parent readme
+		parentPath := cat.CatalogID + "/" + templateID
+		parentMetadata, ok := cat.metadata[parentPath]
+		if ok {
+			newTemplate.ReadmeLink = parentMetadata.ReadmeLink
+		} else {
+			log.Debugf("Could not find the parent metadata %s", parentPath)
+		}
+	}
+
+	return &newTemplate, true
+
+}

--- a/manager/catalog_manager.go
+++ b/manager/catalog_manager.go
@@ -3,39 +3,34 @@ package manager
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	//"io/ioutil"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/rancher/go-rancher/client"
 	"github.com/rancher/rancher-catalog-service/model"
-	"gopkg.in/yaml.v2"
 )
 
 var (
-	catalogURL      = flag.String("catalogUrl", "", "Git repo url containing catalog (such as a public GitHub repo url)")
+	catalogURLList  = flag.String("catalogUrlList", "", "Comma separated list providing a git repo id and git repo urls (such as a public GitHub repo url) in the form of id1:url1,id2:url2... ")
 	refreshInterval = flag.Int64("refreshInterval", 60, "Time interval (in Seconds) to periodically pull the catalog from git repo")
 	logFile         = flag.String("logFile", "", "Log file")
 	debug           = flag.Bool("debug", false, "Debug")
 	// Port is the listen port of the HTTP server
 	Port              = flag.Int("port", 8088, "HTTP listen port")
-	metadataFolder    = regexp.MustCompile(`^DATA/templates/[^/]+$`)
 	refreshReqChannel = make(chan int, 1)
-	//Catalog is the map storing template metadata in memory
-	Catalog map[string]model.Template
-	//UUIDToPath holds the mapping between a template UUID to the path in the repo
-	UUIDToPath map[string]string
+	//CatalogsCollection is the map storing template catalogs
+	CatalogsCollection map[string]*Catalog
 	//CatalogReadyChannel signals if the catalog is cloned and loaded in memmory
 	CatalogReadyChannel = make(chan int, 1)
+	//UUIDToPath holds the mapping between a template UUID to the path in the repo
+	UUIDToPath map[string]string
 )
 
-const catalogRoot string = "./DATA/templates/"
+//CatalogRootDir is the root folder under which all catalogs are cloned
+const CatalogRootDir string = "./DATA/"
 
 //SetEnv parses the command line args and sets the necessary variables
 func SetEnv() {
@@ -58,19 +53,39 @@ func SetEnv() {
 	}
 	log.SetFormatter(textFormatter)
 
-	if *catalogURL == "" {
+	if *catalogURLList == "" {
 		err := "Halting Catalog service, Catalog git repo url not provided"
 		log.Fatal(err)
 		_ = fmt.Errorf(err)
+	} else {
+		urlList := strings.TrimSpace(*catalogURLList)
+		//parse the comma separated list into catalog structs
+		urls := strings.Split(urlList, ",")
+		CatalogsCollection = make(map[string]*Catalog)
+		UUIDToPath = make(map[string]string)
+
+		for _, value := range urls {
+			value = strings.TrimSpace(value)
+			if value != "" {
+				catalogProps := strings.SplitN(value, ":", 2)
+				newCatalog := Catalog{}
+				newCatalog.CatalogID = catalogProps[0]
+				newCatalog.url = catalogProps[1]
+				refChan := make(chan int, 1)
+				newCatalog.refreshReqChannel = &refChan
+				newCatalog.catalogRoot = CatalogRootDir + catalogProps[0]
+				CatalogsCollection[catalogProps[0]] = &newCatalog
+			}
+		}
 	}
 }
 
 //Init clones or pulls the catalog, starts background refresh thread
 func Init() {
-	_, err := os.Stat(catalogRoot)
+	_, err := os.Stat(CatalogRootDir)
 	if !os.IsNotExist(err) || err == nil {
 		//remove the existing repo
-		err := os.RemoveAll("./DATA/")
+		err := os.RemoveAll(CatalogRootDir)
 		if err != nil {
 			log.Fatal("Cannot remove the existing catalog data folder ./DATA/", err)
 			_ = fmt.Errorf("Cannot remove the existing catalog data folder ./DATA/, error: " + err.Error())
@@ -78,10 +93,10 @@ func Init() {
 	} else {
 		log.Info("./DATA/ folder does not exist, proceeding to clone the repo : ", err)
 	}
-	cloneCatalog()
-	UUIDToPath = make(map[string]string)
-	Catalog = make(map[string]model.Template)
-	filepath.Walk(catalogRoot, walkCatalog)
+
+	for _, catalog := range CatalogsCollection {
+		catalog.cloneCatalog()
+	}
 
 	//start a background timer to pull from the Catalog periodically
 	startCatalogBackgroundPoll()
@@ -93,247 +108,79 @@ func startCatalogBackgroundPoll() {
 	go func() {
 		for t := range ticker.C {
 			log.Debugf("Running background Catalog Refresh Thread at time %s", t)
-			RefreshCatalog()
+			RefreshAllCatalogs()
 		}
 	}()
 }
 
-//RefreshCatalog syncs the catalog from the repo
-func RefreshCatalog() {
-	//put msg on channel, so that any other request can wait
-	select {
-	case refreshReqChannel <- 1:
-		err := pullCatalog()
-		if err == nil {
-			log.Debug("Refreshing the catalog...")
-			Catalog = make(map[string]model.Template)
-			filepath.Walk(catalogRoot, walkCatalog)
-		} else {
-			log.Debugf("Will not refresh the catalog since Pull Catalog faced error: %v", err)
-		}
-		<-refreshReqChannel
-	default:
-		log.Info("Refresh catalog is already in process, skipping")
+//RefreshAllCatalogs refreshes the catalogs by syncing changes from github
+func RefreshAllCatalogs() {
+	for _, catalog := range CatalogsCollection {
+		log.Debugf("Refreshing catalog %s", catalog.getID())
+		catalog.refreshCatalog()
 	}
 }
 
-func cloneCatalog() {
-	log.Infof("Cloning the catalog from git url %s", *catalogURL)
-	//git clone the repo
-	e := exec.Command("git", "clone", *catalogURL, "./DATA")
-	e.Stdout = os.Stdout
-	e.Stderr = os.Stderr
-	err := e.Run()
-	if err != nil {
-		log.Fatal("Failed to clone the catalog from remote git repository", err.Error())
+//ListAllCatalogs lists the catalog id's and links
+func ListAllCatalogs() []Catalog {
+	var catalogCollection []Catalog
+	for catalogID := range CatalogsCollection {
+		catalog := Catalog{}
+		catalog.CatalogID = catalogID
+		catalog.CatalogLink = catalogID + "/templates"
+		catalogCollection = append(catalogCollection, catalog)
 	}
+	return catalogCollection
 }
 
-func pullCatalog() error {
-	log.Debug("Pulling the catalog from the repo to sync any new changes")
-
-	e := exec.Command("git", "-C", "./DATA", "fetch", "--all")
-	err := e.Run()
-	if err != nil {
-		log.Errorf("Failed to fetch all from the git repo %s, error: %v", *catalogURL, err)
-		return err
+//GetCatalog gets the metadata of the specified catalog
+func GetCatalog(catalogID string) (Catalog, bool) {
+	cat, ok := CatalogsCollection[catalogID]
+	catalog := Catalog{}
+	if ok {
+		catalog.CatalogID = cat.CatalogID
+		catalog.CatalogLink = cat.CatalogID + "/templates"
 	}
-
-	e = exec.Command("git", "-C", "./DATA", "reset", "--hard", "origin/master")
-	err = e.Run()
-	if err != nil {
-		log.Errorf("Failed to pull the catalog from git repo %s, error: %v", *catalogURL, err)
-		return err
-	}
-
-	return nil
+	return catalog, ok
 }
 
-func walkCatalog(path string, f os.FileInfo, err error) error {
-
-	if f.IsDir() && metadataFolder.MatchString(path) {
-
-		log.Debugf("Reading metadata folder for template:%s", f.Name())
-		newTemplate := model.Template{
-			Resource: client.Resource{
-				Id:   f.Name(),
-				Type: "template",
-			},
-			Path: f.Name(),
+//ListAllTemplates lists the templates from all catalogs
+func ListAllTemplates() []model.Template {
+	var metadataCollection []model.Template
+	for _, catalog := range CatalogsCollection {
+		for _, template := range catalog.metadata {
+			metadataCollection = append(metadataCollection, template)
 		}
-
-		//read the root level config.yml
-		readTemplateConfig(path, &newTemplate)
-
-		//list the folders under the root level
-		newTemplate.VersionLinks = make(map[string]string)
-		newTemplate.TemplateVersionRancherVersion = make(map[string]string)
-		dirList, err := ioutil.ReadDir(path)
-		if err != nil {
-			log.Errorf("Error reading directories at path: %s, error: %v", f.Name(), err)
-		} else {
-			for _, subfile := range dirList {
-				if subfile.IsDir() {
-					//read the subversion config.yml file into a template
-					subTemplate := model.Template{}
-					err := readRancherCompose(f.Name()+"/"+subfile.Name(), &subTemplate)
-					if err == nil {
-						if subTemplate.UUID != "" {
-							UUIDToPath[subTemplate.UUID] = f.Name() + "/" + subfile.Name()
-							log.Debugf("UUIDToPath map: %v", UUIDToPath)
-						}
-						newTemplate.VersionLinks[subTemplate.Version] = f.Name() + "/" + subfile.Name()
-						newTemplate.TemplateVersionRancherVersion[subTemplate.Version] = subTemplate.MinimumRancherVersion
-					} else {
-						log.Errorf("Skipping the template version: %s, error: %v", f.Name()+"/"+subfile.Name(), err)
-					}
-				} else if strings.HasPrefix(subfile.Name(), "catalogIcon") {
-					newTemplate.IconLink = f.Name() + "/" + subfile.Name()
-				} else if strings.HasPrefix(strings.ToLower(subfile.Name()), "readme") {
-					newTemplate.ReadmeLink = f.Name() + "/" + subfile.Name()
-				}
-			}
-		}
-
-		Catalog[f.Name()] = newTemplate
 	}
-	return nil
+	return metadataCollection
 }
 
-//ReadTemplateVersion reads the template version details
-func ReadTemplateVersion(path string) model.Template {
-
-	dirList, err := ioutil.ReadDir(catalogRoot + path)
-	newTemplate := model.Template{}
-	newTemplate.Path = path
-
-	if err != nil {
-		log.Errorf("Error reading template at path: %s, error: %v", path, err)
-	} else {
-
-		var foundIcon, foundReadme bool
-
-		for _, subfile := range dirList {
-			if strings.HasPrefix(subfile.Name(), "catalogIcon") {
-
-				newTemplate.IconLink = path + "/" + subfile.Name()
-				foundIcon = true
-
-			} else if strings.HasPrefix(subfile.Name(), "docker-compose") {
-
-				newTemplate.DockerCompose = string(*(readFile(catalogRoot+path, subfile.Name())))
-
-			} else if strings.HasPrefix(subfile.Name(), "rancher-compose") {
-
-				readRancherCompose(path, &newTemplate)
-			} else if strings.HasPrefix(strings.ToLower(subfile.Name()), "readme") {
-
-				newTemplate.ReadmeLink = path + "/" + subfile.Name()
-				foundReadme = true
-
-			}
-		}
-		if !foundIcon {
-			//use the parent icon
-			tokens := strings.Split(path, "/")
-			parentPath := tokens[0]
-			parentMetadata, ok := Catalog[parentPath]
-			if ok {
-				newTemplate.IconLink = parentMetadata.IconLink
-			} else {
-				log.Debugf("Could not find the parent metadata %s", parentPath)
-			}
-		}
-
-		if !foundReadme {
-			//use the parent icon
-			tokens := strings.Split(path, "/")
-			parentPath := tokens[0]
-			parentMetadata, ok := Catalog[parentPath]
-			if ok {
-				newTemplate.ReadmeLink = parentMetadata.ReadmeLink
-			} else {
-				log.Debugf("Could not find the parent metadata %s", parentPath)
-			}
+//ListTemplatesForCatalog lists the templates from the given catalog
+func ListTemplatesForCatalog(catalogID string) []model.Template {
+	var metadataCollection []model.Template
+	cat, ok := CatalogsCollection[catalogID]
+	if ok {
+		for _, template := range cat.metadata {
+			metadataCollection = append(metadataCollection, template)
 		}
 	}
-
-	return newTemplate
-
+	return metadataCollection
 }
 
-func readTemplateConfig(relativePath string, template *model.Template) {
-	filename, err := filepath.Abs(relativePath + "/config.yml")
-	if err != nil {
-		log.Errorf("Error forming path to config file at path: %s, error: %v", relativePath, err)
-	}
-
-	yamlFile, err := ioutil.ReadFile(filename)
-	if err != nil {
-		log.Errorf("Error reading config file under template: %s, error: %v", relativePath, err)
-	} else {
-		config := make(map[string]string)
-
-		//Read the config.yml file
-		err = yaml.Unmarshal(yamlFile, &config)
-		if err != nil {
-			log.Errorf("Error unmarshalling config.yml under template: %s, error: %v", relativePath, err)
-		} else {
-			template.Name = config["name"]
-			template.Category = config["category"]
-			template.Description = config["description"]
-			template.Version = config["version"]
-			if config["uuid"] != "" {
-				template.UUID = config["uuid"]
-			}
-			template.Maintainer = config["maintainer"]
-			template.License = config["license"]
-			template.ProjectURL = config["projectURL"]
-		}
-	}
+//GetTemplateMetadata gets the metadata of the specified template from the given catalog
+func GetTemplateMetadata(catalogID string, templateID string) (model.Template, bool) {
+	cat := CatalogsCollection[catalogID]
+	template, ok := cat.metadata[catalogID+"/"+templateID]
+	return template, ok
 }
 
-func readRancherCompose(relativePath string, newTemplate *model.Template) error {
-
-	composeBytes := readFile(catalogRoot+relativePath, "rancher-compose.yml")
-	newTemplate.RancherCompose = string(*composeBytes)
-
-	//read the questions section
-	RC := make(map[string]model.RancherCompose)
-	err := yaml.Unmarshal(*composeBytes, &RC)
-	if err != nil {
-		log.Errorf("Error unmarshalling %s under template: %s, error: %v", "rancher-compose.yml", relativePath, err)
-		return err
+//ReadTemplateVersion reads the details of a template version
+func ReadTemplateVersion(catalogID string, templateID string, versionID string) (*model.Template, bool) {
+	cat, ok := CatalogsCollection[catalogID]
+	if ok {
+		return cat.ReadTemplateVersion(templateID, versionID)
 	}
-	newTemplate.Questions = RC[".catalog"].Questions
-	newTemplate.Name = RC[".catalog"].Name
-	newTemplate.UUID = RC[".catalog"].UUID
-	newTemplate.Description = RC[".catalog"].Description
-	newTemplate.Version = RC[".catalog"].Version
-	newTemplate.MinimumRancherVersion = RC[".catalog"].MinimumRancherVersion
-	newTemplate.Output = RC[".catalog"].Output
-
-	if newTemplate.UUID != "" {
-		//store uuid -> path map
-		UUIDToPath[newTemplate.UUID] = relativePath
-		log.Debugf("UUIDToPath map: %v", UUIDToPath)
-	}
-	return nil
-
-}
-
-func readFile(relativePath string, fileName string) *[]byte {
-	filename, err := filepath.Abs(relativePath + "/" + fileName)
-	if err != nil {
-		log.Errorf("Error forming path to file %s, error: %v", relativePath+"/"+fileName, err)
-	}
-
-	composeBytes, err := ioutil.ReadFile(filename)
-	if err != nil {
-		log.Errorf("Error reading file %s, error: %v", relativePath+"/"+fileName, err)
-		return nil
-	}
-	return &composeBytes
+	return nil, ok
 }
 
 //GetNewTemplateVersions gets new versions of a template if available
@@ -341,26 +188,29 @@ func GetNewTemplateVersions(templateUUID string) (model.Template, bool) {
 	templateMetadata := model.Template{}
 	path := UUIDToPath[templateUUID]
 	if path != "" {
-		//refresh the catalog and sync any new changes
-		RefreshCatalog()
-
 		//find the base template metadata name
 		tokens := strings.Split(path, "/")
-		parentPath := tokens[0]
-		cVersion := tokens[1]
+		catalogID := tokens[0]
+		parentPath := tokens[1]
+		cVersion := tokens[2]
+
+		//refresh the catalog and sync any new changes
+		cat := CatalogsCollection[catalogID]
+		//cat.refreshCatalog()
+
 		currentVersion, err := strconv.Atoi(cVersion)
 
 		if err != nil {
 			log.Debugf("Error %v reading Current Version from path: %s for uuid: %s", err, path, templateUUID)
 		} else {
-			templateMetadata, ok := Catalog[parentPath]
+			templateMetadata, ok := cat.metadata[catalogID+"/"+parentPath]
 			if ok {
 				log.Debugf("Template found by uuid: %s", templateUUID)
 				copyOfversionLinks := make(map[string]string)
 				for key, value := range templateMetadata.VersionLinks {
 					if value != path {
 						otherVersionTokens := strings.Split(value, "/")
-						oVersion := otherVersionTokens[1]
+						oVersion := otherVersionTokens[2]
 						otherVersion, err := strconv.Atoi(oVersion)
 
 						if err == nil && otherVersion > currentVersion {

--- a/service/routes.go
+++ b/service/routes.go
@@ -72,12 +72,14 @@ func NewRouter() *mux.Router {
 
 	// API framework routes
 	router := mux.NewRouter().StrictSlash(true)
+
 	router.Methods("GET").Path("/").Handler(api.VersionsHandler(schemas, "v1-catalog"))
 	router.Methods("GET").Path("/v1-catalog/schemas").Handler(api.SchemasHandler(schemas))
 	router.Methods("GET").Path("/v1-catalog/schemas/{id}").Handler(api.SchemaHandler(schemas))
 	router.Methods("GET").Path("/v1-catalog").Handler(api.VersionHandler(schemas, "v1-catalog"))
 
 	// Application routes
+
 	for _, route := range routes {
 		router.
 			Methods(route.Method).
@@ -101,37 +103,37 @@ var routes = Routes{
 	Route{
 		"LoadTemplateMetadata",
 		"GET",
-		"/v1-catalog/templates/{templateId}",
+		"/v1-catalog/templates/{catalogId}/{templateId}",
 		LoadTemplateMetadata,
 	},
 	Route{
 		"LoadTemplateVersion",
 		"GET",
-		"/v1-catalog/templates/{templateId}/{versionId}",
+		"/v1-catalog/templates/{catalogId}/{templateId}/{versionId}",
 		LoadTemplateVersion,
 	},
 	Route{
 		"LoadVersionImage",
 		"GET",
-		"/v1-catalog/images/{templateId}/{versionId}/{imageId}",
+		"/v1-catalog/images/{catalogId}/{templateId}/{versionId}/{imageId}",
 		LoadImage,
 	},
 	Route{
 		"LoadImage",
 		"GET",
-		"/v1-catalog/images/{templateId}/{imageId}",
+		"/v1-catalog/images/{catalogId}/{templateId}/{imageId}",
 		LoadImage,
 	},
 	Route{
 		"LoadVersionFile",
 		"GET",
-		"/v1-catalog/files/{templateId}/{versionId}/{fileId}",
+		"/v1-catalog/files/{catalogId}/{templateId}/{versionId}/{fileId}",
 		LoadFile,
 	},
 	Route{
 		"LoadFile",
 		"GET",
-		"/v1-catalog/files/{templateId}/{fileId}",
+		"/v1-catalog/files/{catalogId}/{templateId}/{fileId}",
 		LoadFile,
 	},
 	Route{
@@ -146,5 +148,23 @@ var routes = Routes{
 		"GET",
 		"/v1-catalog/upgradeinfo/{templateUUID}",
 		GetUpgradeInfo,
+	},
+	Route{
+		"ListCatalogs",
+		"GET",
+		"/v1-catalog/catalogs",
+		ListCatalogs,
+	},
+	Route{
+		"GetCatalog",
+		"GET",
+		"/v1-catalog/catalogs/{catalogId}",
+		GetCatalog,
+	},
+	Route{
+		"GetTemplatesForCatalog",
+		"GET",
+		"/v1-catalog/catalogs/{catalogId}/templates",
+		GetTemplatesForCatalog,
 	},
 }


### PR DESCRIPTION
- Accepts a comma separated list of git repo urls in the format id1:url1,id2:url2,...
  API /v1-catalog/templates will list templates from all catalogs
  API /v1-catalog/templates?catalog={catalog_id} will list templates from specified catalog
- Also added new API to list Catalogs /v1-catalog/catalogs. 

- Changed code use git pull instead of git reset to refresh the Catalogs

- Added id to the template version as catalog:template_name:version