### PR TITLE
Fixing the self link and version links to templates by adding an 'id'

### DIFF
--- a/manager/catalog.go
+++ b/manager/catalog.go
@@ -89,7 +89,7 @@ func (cat *Catalog) walkCatalog(path string, f os.FileInfo, err error) error {
 							UUIDToPath[subTemplate.UUID] = newTemplate.Path + "/" + subfile.Name()
 							log.Debugf("UUIDToPath map: %v", UUIDToPath)
 						}
-						newTemplate.VersionLinks[subTemplate.Version] = newTemplate.Path + "/" + subfile.Name()
+						newTemplate.VersionLinks[subTemplate.Version] = newTemplate.Id + ":" + subfile.Name()
 						newTemplate.TemplateVersionRancherVersion[subTemplate.Version] = subTemplate.MinimumRancherVersion
 					} else {
 						log.Errorf("Skipping the template version: %s, error: %v", f.Name()+"/"+subfile.Name(), err)

--- a/manager/catalog.go
+++ b/manager/catalog.go
@@ -1,16 +1,17 @@
 package manager
 
 import (
-	log "github.com/Sirupsen/logrus"
-	"github.com/rancher/go-rancher/client"
-	"github.com/rancher/rancher-catalog-service/model"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/rancher/go-rancher/client"
+	"github.com/rancher/rancher-catalog-service/model"
+	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -62,7 +63,7 @@ func (cat *Catalog) walkCatalog(path string, f os.FileInfo, err error) error {
 		log.Debugf("Reading metadata folder for template:%s, path: %v", f.Name(), path)
 		newTemplate := model.Template{
 			Resource: client.Resource{
-				Id:   f.Name(),
+				Id:   cat.CatalogID + ":" + f.Name(),
 				Type: "template",
 			},
 			Path: cat.CatalogID + "/" + f.Name(), //catalogRoot + f.Name()
@@ -108,7 +109,7 @@ func (cat *Catalog) walkCatalog(path string, f os.FileInfo, err error) error {
 }
 
 func (cat *Catalog) pullCatalog() error {
-	log.Infof("Pulling the catalog %s from the repo to sync any new changes to %s", cat.CatalogID, cat.catalogRoot)
+	log.Debugf("Pulling the catalog %s from the repo to sync any new changes to %s", cat.CatalogID, cat.catalogRoot)
 
 	e := exec.Command("git", "-C", cat.catalogRoot, "pull", "-r", "origin", "master")
 

--- a/service/routes.go
+++ b/service/routes.go
@@ -101,16 +101,10 @@ var routes = Routes{
 		ListTemplates,
 	},
 	Route{
-		"LoadTemplateMetadata",
+		"LoadTemplateDetails",
 		"GET",
-		"/v1-catalog/templates/{catalogId}/{templateId}",
-		LoadTemplateMetadata,
-	},
-	Route{
-		"LoadTemplateVersion",
-		"GET",
-		"/v1-catalog/templates/{catalogId}/{templateId}/{versionId}",
-		LoadTemplateVersion,
+		"/v1-catalog/templates/{catalog_template_Id}",
+		LoadTemplateDetails,
 	},
 	Route{
 		"LoadVersionImage",


### PR DESCRIPTION
Fixed the self link and version links to templates by adding an 'id' of the form catalog:template:version