### PR TITLE
Changes to use ':' as the separator in the template id. 

### DIFF
--- a/manager/catalog_manager.go
+++ b/manager/catalog_manager.go
@@ -239,7 +239,7 @@ func GetNewTemplateVersions(path string) (model.Template, bool) {
 			copyOfversionLinks := make(map[string]string)
 			for key, value := range templateMetadata.VersionLinks {
 				if value != path {
-					otherVersionTokens := strings.Split(value, "/")
+					otherVersionTokens := strings.Split(value, ":")
 					oVersion := otherVersionTokens[2]
 					otherVersion, err := strconv.Atoi(oVersion)
 

--- a/service/routes.go
+++ b/service/routes.go
@@ -115,22 +115,16 @@ var routes = Routes{
 		ListTemplates,
 	},
 	Route{
-		"LoadTemplateMetadata",
+		"LoadTemplateDetails",
 		"GET",
-		"/v1-catalog/templates/{catalogId}/{templateId}",
-		LoadTemplateMetadata,
+		"/v1-catalog/templates/{catalog_template_version_Id}",
+		LoadTemplateDetails,
 	},
 	Route{
 		"",
 		"GET",
-		"/v1-catalog/templates/{catalogId}/{templateId}/{versionId}",
-		LoadTemplateVersion,
-	},
-	Route{
-		"",
-		"GET",
-		"/v1-catalog/templateversions/{catalogId}/{templateId}/{versionId}",
-		LoadTemplateVersion,
+		"/v1-catalog/templateversions/{catalog_template_version_Id}",
+		LoadTemplateDetails,
 	},
 	Route{
 		"LoadVersionImage",


### PR DESCRIPTION
So the id will be of format catalogId:templateId:versionId

Changed the routes accordingly to /v1-catalog/templates/{id}