### PR TITLE
Change the way images and readme file is accessed

### DIFF
--- a/manager/catalog_manager.go
+++ b/manager/catalog_manager.go
@@ -36,8 +36,12 @@ var (
 	CatalogsCollection map[string]*Catalog
 	//CatalogReadyChannel signals if the catalog is cloned and loaded in memmory
 	CatalogReadyChannel = make(chan int, 1)
-	//UUIDToPath holds the mapping between a template UUID to the path in the repo
-	UUIDToPath map[string]string
+
+	//PathToImage holds the mapping between a template path in the repo to its image name
+	PathToImage map[string]string
+	//PathToReadme holds the mapping between a template path in the repo to its readme file name
+	PathToReadme map[string]string
+
 	catalogURL arrayFlags
 )
 
@@ -68,7 +72,8 @@ func SetEnv() {
 
 	if catalogURL != nil {
 		CatalogsCollection = make(map[string]*Catalog)
-		UUIDToPath = make(map[string]string)
+		PathToImage = make(map[string]string)
+		PathToReadme = make(map[string]string)
 		defaultFound := false
 
 		for _, value := range catalogURL {

--- a/service/routes.go
+++ b/service/routes.go
@@ -127,30 +127,6 @@ var routes = Routes{
 		LoadTemplateDetails,
 	},
 	Route{
-		"LoadVersionImage",
-		"GET",
-		"/v1-catalog/images/{catalogId}/{templateId}/{versionId}/{imageId}",
-		LoadImage,
-	},
-	Route{
-		"LoadImage",
-		"GET",
-		"/v1-catalog/images/{catalogId}/{templateId}/{imageId}",
-		LoadImage,
-	},
-	Route{
-		"LoadVersionFile",
-		"GET",
-		"/v1-catalog/files/{catalogId}/{templateId}/{versionId}/{fileId}",
-		LoadFile,
-	},
-	Route{
-		"LoadFile",
-		"GET",
-		"/v1-catalog/files/{catalogId}/{templateId}/{fileId}",
-		LoadFile,
-	},
-	Route{
 		"RefreshCatalog",
 		"POST",
 		"/v1-catalog/templates",


### PR DESCRIPTION
Routes changed to 
/v1-catalog/templates/{id}?image
/v1-catalog/templates/{id}?readme