### PR TITLE
Changes to continue running catalog service even if one catalog fails to clone

### DIFF
--- a/integration/core/test_api.py
+++ b/integration/core/test_api.py
@@ -11,3 +11,12 @@ def client():
 def test_catalog_list(client):
     templates = client.list_template()
     assert len(templates) > 0
+
+
+def test_catalog_state_uri_present(client):
+    catalogs = client.list_catalog()
+    assert len(catalogs) > 0
+
+    for i in range(len(catalogs)):
+        assert catalogs[i].state is not None
+        assert catalogs[i].uri is not None

--- a/manager/catalog_manager.go
+++ b/manager/catalog_manager.go
@@ -55,7 +55,7 @@ const CatalogRootDir string = "./DATA/"
 
 //SetEnv parses the command line args and sets the necessary variables
 func SetEnv() {
-	flag.Var(&catalogURL, "catalogUrl", "git repo url in the form repo_id:repo_url. Specify the flag multiple times for multiple repos")
+	flag.Var(&catalogURL, "catalogUrl", "git repo url in the form repo_id=repo_url. Specify the flag multiple times for multiple repos")
 	flag.Parse()
 
 	if *debug {
@@ -86,6 +86,7 @@ func SetEnv() {
 		defaultFound := false
 
 		for _, value := range catalogURL {
+			log.Debug("url %s", value)
 			value = strings.TrimSpace(value)
 			if value != "" {
 				urls := strings.Split(value, ",")
@@ -102,7 +103,7 @@ func SetEnv() {
 					}
 					newCatalog := Catalog{}
 					newCatalog.CatalogID = tokens[0]
-					newCatalog.url = tokens[1]
+					newCatalog.URL = tokens[1]
 					refChan := make(chan int, 1)
 					newCatalog.refreshReqChannel = &refChan
 					newCatalog.catalogRoot = CatalogRootDir + tokens[0]
@@ -162,7 +163,7 @@ func RefreshAllCatalogs() {
 //ListAllCatalogs lists the catalog id's and links
 func ListAllCatalogs() []Catalog {
 	var catalogCollection []Catalog
-	for catalogID := range CatalogsCollection {
+	for catalogID, cat := range CatalogsCollection {
 		catalog := Catalog{
 			Resource: client.Resource{
 				Id:   catalogID,
@@ -171,6 +172,10 @@ func ListAllCatalogs() []Catalog {
 		}
 		catalog.CatalogID = catalogID
 		catalog.CatalogLink = catalogID + "/templates"
+		catalog.State = cat.State
+		catalog.URL = cat.URL
+		catalog.Message = cat.Message
+		catalog.LastUpdated = cat.LastUpdated
 		catalogCollection = append(catalogCollection, catalog)
 	}
 	return catalogCollection
@@ -187,6 +192,10 @@ func GetCatalog(catalogID string) (Catalog, bool) {
 	if ok {
 		catalog.Id = cat.CatalogID
 		catalog.CatalogID = cat.CatalogID
+		catalog.State = cat.State
+		catalog.URL = cat.URL
+		catalog.Message = cat.Message
+		catalog.LastUpdated = cat.LastUpdated
 		catalog.CatalogLink = cat.CatalogID + "/templates"
 	}
 	return catalog, ok


### PR DESCRIPTION
There is repeated attempts made to clone all catalogs when there is a failure encountered in cloning one of the catalogs. 
This happens because catalog service halts upon failure and rancher server keeps on restarting the service.

Fixed the service to not halt upon failure to clone for one catalog when multiple catalogs are provided.

https://github.com/rancher/rancher/issues/3003
https://github.com/rancher/rancher/issues/3004
https://github.com/rancher/rancher/issues/3002