### PR TITLE
Changes to support kubernetes-templates/ folder in the repo

### DIFF
--- a/integration/core/test_api.py
+++ b/integration/core/test_api.py
@@ -52,3 +52,33 @@ def test_template_not_found(client):
     assert error['message'] is not None
     assert error['status'] is not None
     assert error['status'] == "404"
+
+
+def test_templatebase_eq_filter(client):
+    templates = client.list_template(templateBase_eq='invalid')
+    assert len(templates) == 0
+
+
+def test_templatebase_ne_filter(client):
+    templates = client.list_template(templateBase_ne='invalid')
+    assert len(templates) > 0
+
+
+def test_template_files_map(client):
+    templates = client.list_template()
+    assert len(templates) > 0
+    versionUrls = templates[0].versionLinks.values()
+
+    url = versionUrls[0]
+    response = requests.get(url)
+    assert response.status_code == 200
+    resp = response.json()
+    assert resp['files'] is not None
+    assert resp['files']['rancher-compose.yml'] is not None
+
+
+def test_template_base(client):
+    templates = client.list_template()
+    assert len(templates) > 0
+    for i in range(len(templates)):
+        assert templates[i].templateBase is not None

--- a/model/template.go
+++ b/model/template.go
@@ -14,8 +14,7 @@ type Template struct {
 	IconLink                      string            `json:"iconLink"`
 	VersionLinks                  map[string]string `json:"versionLinks"`
 	UpgradeVersionLinks           map[string]string `json:"upgradeVersionLinks"`
-	DockerCompose                 string            `json:"dockerCompose"`
-	RancherCompose                string            `json:"rancherCompose"`
+	Files                         map[string]string `json:"files"`
 	Questions                     []Question        `json:"questions"`
 	Path                          string            `json:"path"`
 	MinimumRancherVersion         string            `json:"minimumRancherVersion"`
@@ -25,6 +24,7 @@ type Template struct {
 	ProjectURL                    string `json:"projectURL"`
 	ReadmeLink                    string `json:"readmeLink"`
 	Output                        Output `json:"output" yaml:"output,omitempty"`
+	TemplateBase                  string `json:"templateBase"`
 }
 
 //TemplateCollection holds a collection of templates

--- a/service/routes.go
+++ b/service/routes.go
@@ -127,6 +127,7 @@ func NewRouter() *mux.Router {
 	}
 
 	router.GetRoute("RefreshCatalog").Queries("action", "refresh")
+	router.GetRoute("RefreshCatalogTemplates").Queries("action", "refresh")
 
 	return router
 }
@@ -154,6 +155,12 @@ var routes = Routes{
 		"RefreshCatalog",
 		"POST",
 		"/v1-catalog/templates",
+		RefreshCatalog,
+	},
+	Route{
+		"RefreshCatalogTemplates",
+		"POST",
+		"/v1-catalog/catalogs/{catalogId}/templates",
 		RefreshCatalog,
 	},
 	//http://<server_ip>:8088/v1/upgrades/<template_uuid>


### PR DESCRIPTION
The folder should be at same level as templates/ folder.
Any such folder at same level as templates/ can be supported, provided
it has name of format {xyz}-templates/

By default, all the templates under templates/ and say {xyz}-templates/ folders
will be loaded by http://localhost:8088/v1-catalog/templates/

To list only the contents of say the kubernetes-templates folder, pass filter
http://localhost:8088/v1-catalog/templates?templateBase_eq=kubernetes
[http://localhost:8088/v1-catalog/templates?templateBase_eq=xyz]

To not list the contents of such a folder, pass filter
http://localhost:8088/v1-catalog/templates?templateBase_ne=kubernetes
[http://localhost:8088/v1-catalog/templates?templateBase_ne=xyz]

Also, the fields 'rancher-compose' and 'docker-compose' will not be present anymore on a template response. Instead each template version will have a 'files' map of
filename:content(as a string) to list any file under that template
version.
docker-compose.yml and rancher-compose.yml will also be part of this map
and not specified as separate fields.

Also the templates have a property templateBase which will have the
value 'xyz' for templates under xyz-templates folder