### PR TITLE
The URLEncoding should be applied after forming the complete URL 

### DIFF
--- a/service/handlers.go
+++ b/service/handlers.go
@@ -353,7 +353,7 @@ func PopulateTemplateLinks(r *http.Request, template *model.Template) map[string
 
 	copyOfversionLinks := make(map[string]string)
 	for key, value := range template.VersionLinks {
-		copyOfversionLinks[key] = apiContext.UrlBuilder.ReferenceByIdLink("template", URLEncoded(value))
+		copyOfversionLinks[key] = URLEncoded(apiContext.UrlBuilder.ReferenceByIdLink("template", value))
 	}
 
 	template.Links["icon"] = URLEncoded(apiContext.UrlBuilder.ReferenceByIdLink("template", template.IconLink))


### PR DESCRIPTION
Url encoding was being applied to the template ID itself and that caused the templateId to be added with the first letter lowercase to the versrionLinks (since URLEncoder thinks its the scheme in a valid url)

Fixed this by encoding after forming the url for the versions.

Tested manually, cannot add a specifc test for this fix.

Issue: https://github.com/rancher/rancher/issues/3955
Issue: https://github.com/rancher/rancher/issues/3971