### PR TITLE
Changes to support pre-cloned catalog present on disk.

### DIFF
--- a/manager/catalog_manager.go
+++ b/manager/catalog_manager.go
@@ -121,20 +121,8 @@ func SetEnv() {
 
 //Init clones or pulls the catalog, starts background refresh thread
 func Init() {
-	_, err := os.Stat(CatalogRootDir)
-	if !os.IsNotExist(err) || err == nil {
-		//remove the existing repo
-		err := os.RemoveAll(CatalogRootDir)
-		if err != nil {
-			log.Fatal("Cannot remove the existing catalog data folder ./DATA/", err)
-			_ = fmt.Errorf("Cannot remove the existing catalog data folder ./DATA/, error: " + err.Error())
-		}
-	} else {
-		log.Info("./DATA/ folder does not exist, proceeding to clone the repo : ", err)
-	}
-
 	for _, catalog := range CatalogsCollection {
-		catalog.cloneCatalog()
+		catalog.readCatalog()
 	}
 
 	//start a background timer to pull from the Catalog periodically


### PR DESCRIPTION
The service now first checks if the catalog by its name and repoURL
already exists under ./DATA/ folder. If it does then it just pulls
updates and serves the catalog without cloning newly. In case the pull
fails then whatever is on the disk is served.

If the catalogName or repoURL do not match to existing catalog, then
that catalog is newly cloned.

Tested manually, cannot test using integration tests.

https://github.com/rancher/rancher/issues/3964