### PR TITLE
Fix the code that derives the path of a file under a template version

### DIFF
--- a/integration/core/test_api.py
+++ b/integration/core/test_api.py
@@ -82,3 +82,18 @@ def test_template_base(client):
     assert len(templates) > 0
     for i in range(len(templates)):
         assert templates[i].templateBase is not None
+
+
+def test_template_many_versions(client):
+    templates = client.list_template(catalogId='qa-catalog')
+    if len(templates) > 0:
+        for i in range(len(templates)):
+            if templates[i].id == unicode('qa-catalog:many-versions'):
+                versionUrls = templates[i].versionLinks.values()
+                for i in range(len(versionUrls)):
+                    version_response = requests.get(versionUrls[i])
+                    assert version_response is not 404
+                    response_json = version_response.json()
+                    docker_compose = response_json.get(unicode('files'))\
+                        .get(unicode('docker-compose.yml'))
+                    assert docker_compose is not None

--- a/manager/catalog.go
+++ b/manager/catalog.go
@@ -375,20 +375,18 @@ func walkVersion(path string, template *model.Template) (bool, bool, error) {
 func deriveFilePath(templatePath string, path string) string {
 	//template.Path = prachi/ElasticSearch/0
 	//path = ./DATA/prachi/templates/ElasticSearch/0  return ""
-	//path = ./DATA/prachi/templates/ElasticSearch/0/redis return redis
-	//path = ./DATA/prachi/templates/ElasticSearch/0/redis/front  return redis/front
+	//path = ./DATA/prachi/templates/ElasticSearch/0/redis return redis/
+	//path = ./DATA/prachi/templates/ElasticSearch/0/redis/front  return redis/front/
 
 	lastIndexOfSlash := strings.LastIndex(templatePath, "/")
 	if lastIndexOfSlash != -1 {
 		version := templatePath[lastIndexOfSlash+1 : len(templatePath)]
-		lastVersionIndex := strings.LastIndex(path, version)
-		if lastVersionIndex != -1 {
-			var key string
-			if lastVersionIndex != len(path)-1 {
-				key = path[lastVersionIndex+2:] + "/"
-			}
-			return key
+		parts := strings.SplitAfter(path, "/"+version+"/")
+		var key string
+		if len(parts) > 1 {
+			key = parts[1] + "/"
 		}
+		return key
 	}
 
 	return path + "/"

--- a/scripts/test
+++ b/scripts/test
@@ -10,7 +10,15 @@ fi
 # Create broken git repo.
 ./scripts/test-warm
 
-./bin/rancher-catalog-service -catalogUrl https://github.com/rancher/rancher-catalog.git -port 8088 &
+
+
+if [ "$CATALOG_URL" = "" ]
+then
+   CATALOG_URL="rancher=https://github.com/rancher/rancher-catalog.git,qa-catalog=https://github.com/rancher/qa-catalog"
+fi
+
+
+./bin/rancher-catalog-service -catalogUrl ${CATALOG_URL} -port 8088 &
 trap "kill $!" exit
 cd integration
 tox -e flake8,py27


### PR DESCRIPTION
Fix the code that derives the path to be put in the "files" map.

It was broken for a template version having multiple digits due to indexOf calculations

Now the fix is to split the path around the version and use the latter part.

https://github.com/rancher/rancher/issues/4195