### PR TITLE
Branch support

### DIFF
--- a/integration/core/test_api.py
+++ b/integration/core/test_api.py
@@ -21,6 +21,7 @@ def test_catalog_state_uri_present(client):
     for i in range(len(catalogs)):
         assert catalogs[i].state is not None
         assert catalogs[i].uri is not None
+        assert catalogs[i].branch is not None
 
 
 def test_template_list(client):

--- a/main.go
+++ b/main.go
@@ -14,7 +14,9 @@ func main() {
 	router := service.NewRouter()
 	handler := service.MuxWrapper{false, router}
 
-	manager.SetEnv()
+	manager.GetCommandLine()
+
 	go manager.Init()
+	manager.WatchSignals()
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *manager.Port), &handler))
 }

--- a/manager/catalog_manager.go
+++ b/manager/catalog_manager.go
@@ -1,12 +1,15 @@
 package manager
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
-	//"io/ioutil"
+	"io/ioutil"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -15,6 +18,13 @@ import (
 )
 
 type arrayFlags []string
+
+//CatalogInput stores catalogs accepted from JSON file
+type CatalogInput struct {
+	Name    string
+	RepoURL string
+	Branch  string
+}
 
 func (i *arrayFlags) String() string {
 	return fmt.Sprint(*i)
@@ -26,10 +36,11 @@ func (i *arrayFlags) Set(value string) error {
 }
 
 var (
-	refreshInterval = flag.Int64("refreshInterval", 60, "Time interval (in Seconds) to periodically pull the catalog from git repo")
-	logFile         = flag.String("logFile", "", "Log file")
-	debug           = flag.Bool("debug", false, "Debug")
-	validate        = flag.Bool("validate", false, "Validate catalog yaml and exit")
+	refreshInterval  = flag.Int64("refreshInterval", 60, "Time interval (in Seconds) to periodically pull the catalog from git repo")
+	logFile          = flag.String("logFile", "", "Log file")
+	debug            = flag.Bool("debug", false, "Debug")
+	validate         = flag.Bool("validate", false, "Validate catalog yaml and exit")
+	catalogURLBranch = flag.String("catalogURLBranch", "", "Branch name")
 
 	// Port is the listen port of the HTTP server
 	Port              = flag.Int("port", 8088, "HTTP listen port")
@@ -47,16 +58,90 @@ var (
 	//ValidationMode is used to determine if code is just checking Yaml syntax
 	ValidationMode bool
 
-	catalogURL arrayFlags
+	catalogURL     arrayFlags
+	commandLineURL arrayFlags
+
+	//URLBranchMap aps repo url to branch
+	URLBranchMap map[string]string
+
+	reloadChan = make(chan chan error)
 )
 
 //CatalogRootDir is the root folder under which all catalogs are cloned
 const CatalogRootDir string = "./DATA/"
 
+//WatchSignals handles SIGHUP
+func WatchSignals() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGHUP)
+
+	go func() {
+		for _ = range c {
+			log.Info("Received HUP signal")
+			SetEnv()
+			go Init()
+		}
+	}()
+}
+
+//GetCommandLine parses the command line args
+func GetCommandLine() {
+	flag.Var(&catalogURL, "catalogUrl", "git repo url in the form repo_id=repo_url. Specify the flag multiple times for multiple repos")
+
+	flag.Parse()
+	commandLineURL = catalogURL
+	SetEnv()
+}
+
 //SetEnv parses the command line args and sets the necessary variables
 func SetEnv() {
-	flag.Var(&catalogURL, "catalogUrl", "git repo url in the form repo_id=repo_url. Specify the flag multiple times for multiple repos")
-	flag.Parse()
+
+	catalogURL = catalogURL[:0]
+	catalogURL = commandLineURL
+
+	var catalogObject []CatalogInput
+	var catalogObjectJSON []CatalogInput
+	var catalogObjectNonEmptyJSON []CatalogInput
+	var catalogObjectCommandLine []CatalogInput
+	URLBranchMap = make(map[string]string)
+
+	//NEW CODE
+	// If catalog provided through command line
+	if len(catalogURL) > 0 {
+		for i := 0; i < len(catalogURL); i++ {
+			catalogObj := CatalogInput{}
+			catalogObj.RepoURL = catalogURL[i]
+			catalogObj.Branch = "master"
+			catalogObjectCommandLine = append(catalogObjectCommandLine, catalogObj)
+			URLBranchMap[catalogObj.RepoURL] = catalogObj.Branch
+		}
+		catalogObject = append(catalogObject, catalogObjectCommandLine...)
+	}
+
+	libraryContent, err := ioutil.ReadFile("./repo.json")
+	if err != nil {
+		log.Debugf("JSON file does not exist, continuing for command line URLs")
+	} else {
+		err = json.Unmarshal(libraryContent, &catalogObjectJSON)
+		if err != nil {
+			log.Errorf("JSON data format invalid, error : %v\n", err)
+		}
+
+		for objIndex := 0; objIndex < len(catalogObjectJSON); objIndex++ {
+			if (CatalogInput{} != catalogObjectJSON[objIndex]) {
+				catalogObjectNonEmptyJSON = append(catalogObjectNonEmptyJSON, catalogObjectJSON[objIndex])
+			}
+		}
+
+		catalogObjectJSON = catalogObjectNonEmptyJSON
+		catalogObject = append(catalogObject, catalogObjectJSON...)
+
+		for libraryIndex := 0; libraryIndex < len(catalogObjectJSON); libraryIndex++ {
+			catalogObjectJSON[libraryIndex].RepoURL = catalogObjectJSON[libraryIndex].Name + "=" + catalogObjectJSON[libraryIndex].RepoURL
+			catalogURL = append(catalogURL, catalogObjectJSON[libraryIndex].RepoURL)
+			URLBranchMap[catalogObjectJSON[libraryIndex].RepoURL] = catalogObjectJSON[libraryIndex].Branch
+		}
+	}
 
 	if *debug {
 		log.SetLevel(log.DebugLevel)
@@ -78,15 +163,16 @@ func SetEnv() {
 		FullTimestamp: true,
 	}
 	log.SetFormatter(textFormatter)
-
 	if catalogURL != nil {
 		CatalogsCollection = make(map[string]*Catalog)
 		PathToImage = make(map[string]string)
 		PathToReadme = make(map[string]string)
+
 		defaultFound := false
 
 		for _, value := range catalogURL {
-			log.Debugf("url %s", value)
+			*catalogURLBranch = URLBranchMap[value]
+
 			value = strings.TrimSpace(value)
 			if value != "" {
 				urls := strings.Split(value, ",")
@@ -109,6 +195,10 @@ func SetEnv() {
 						//lowercase the scheme
 						url = strings.ToLower(tokens[1][:index]) + tokens[1][index:]
 					}
+					if *catalogURLBranch != "" {
+						newCatalog.URLBranch = *catalogURLBranch
+						newCatalog.catalogBranchDir = CatalogRootDir + tokens[0] //+ "/" + *catalogURLBranch
+					}
 					newCatalog.URL = url
 					refChan := make(chan int, 1)
 					newCatalog.refreshReqChannel = &refChan
@@ -116,6 +206,7 @@ func SetEnv() {
 					CatalogsCollection[tokens[0]] = &newCatalog
 					log.Infof("Using catalog %s=%s", tokens[0], url)
 				}
+				// Init()
 			}
 		}
 	} else {
@@ -168,6 +259,7 @@ func ListAllCatalogs() []Catalog {
 		catalog.CatalogLink = catalogID + "/templates"
 		catalog.State = cat.State
 		catalog.URL = cat.URL
+		catalog.URLBranch = cat.URLBranch
 		catalog.Message = cat.Message
 		catalog.LastUpdated = cat.LastUpdated
 		catalogCollection = append(catalogCollection, catalog)
@@ -188,6 +280,7 @@ func GetCatalog(catalogID string) (Catalog, bool) {
 		catalog.CatalogID = cat.CatalogID
 		catalog.State = cat.State
 		catalog.URL = cat.URL
+		catalog.URLBranch = cat.URLBranch
 		catalog.Message = cat.Message
 		catalog.LastUpdated = cat.LastUpdated
 		catalog.CatalogLink = cat.CatalogID + "/templates"

--- a/repo.json
+++ b/repo.json
@@ -1,7 +1,7 @@
 [
 	{
-		"name":"qa-catalog",
-		"repoURL":"https://github.com/rancher/qa-catalog",
-		"branch":"master"
+		"name":"library",
+		"repoURL":"https://github.com/mrajashree/my-rancher-catalog",
+		"branch":"new_branch"
 	}
 ]

--- a/repo.json
+++ b/repo.json
@@ -1,0 +1,7 @@
+[
+	{
+		"name":"qa-catalog",
+		"repoURL":"https://github.com/rancher/qa-catalog",
+		"branch":"master"
+	}
+]

--- a/scripts/test
+++ b/scripts/test
@@ -14,7 +14,7 @@ fi
 
 if [ "$CATALOG_URL" = "" ]
 then
-   CATALOG_URL="rancher=https://github.com/rancher/rancher-catalog.git,qa-catalog=https://github.com/rancher/qa-catalog"
+   CATALOG_URL="rancher=https://github.com/rancher/rancher-catalog.git"
 fi
 
 

--- a/scripts/test
+++ b/scripts/test
@@ -14,7 +14,7 @@ fi
 
 if [ "$CATALOG_URL" = "" ]
 then
-   CATALOG_URL="rancher=https://github.com/rancher/rancher-catalog.git"
+   CATALOG_URL="rancher=https://github.com/rancher/rancher-catalog.git,qa-catalog=https://github.com/rancher/qa-catalog"
 fi
 
 

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -385,6 +385,11 @@ func loadFile(catalogID string, templateID string, versionID string, fileNameMap
 //RefreshCatalog will be doing a force catalog refresh
 func RefreshCatalog(w http.ResponseWriter, r *http.Request) {
 	log.Infof("Request to refresh catalog")
+
+	//Reload catalog
+	manager.SetEnv()
+	manager.Init()
+
 	manager.RefreshAllCatalogs()
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusNoContent)


### PR DESCRIPTION
Rancher-catalog-service can accept catalog URLs from a JSON file along with the command line argument. A sample JSON file is provided: repo.json. User can include any branch of the repository in the json. The service still accepts all command line args as it did previously