### PR TITLE
Changed format of configFile to an object containing catalogs field

### DIFF
--- a/integration/core/test_api.py
+++ b/integration/core/test_api.py
@@ -187,7 +187,10 @@ def test_template_upgrade_version_links_compare_versions(client):
             if templates[i].name == 'Out of Order Versions':
                 versionUrlsMap = templates[i].versionLinks
         if len(versionUrlsMap) > 0:
-            versionsArray = ["1.0.0","1.0.1","1.0.2","1.0.3","1.0.11","1.1.0","1.1.1","1.2.0","1.2.1","2.0.0-alpha1","2.0.0-alpha2","2.0.0-beta1","2.0.0"]
+            versionsArray = ["1.0.0", "1.0.1", "1.0.2", "1.0.3",
+                             "1.0.11", "1.1.0", "1.1.1", "1.2.0", "1.2.1",
+                             "2.0.0-alpha1", "2.0.0-alpha2", "2.0.0-beta1",
+                             "2.0.0"]
             for key in versionUrlsMap.keys():
                 versionIndex = versionsArray.index(key)
                 url_to_try = versionUrlsMap[key]
@@ -196,7 +199,7 @@ def test_template_upgrade_version_links_compare_versions(client):
                 response_json = version_response.json()
                 upgradeUrls = response_json. \
                     get(unicode('upgradeVersionLinks'))
-                assert sorted(versionsArray[versionIndex+1:]) == sorted(upgradeUrls.keys())
-                assert len(upgradeUrls) == len(versionsArray) - versionIndex - 1
-
-                
+                assert sorted(versionsArray[versionIndex+1:]) \
+                    == sorted(upgradeUrls.keys())
+                assert len(upgradeUrls) == len(versionsArray) \
+                    - versionIndex - 1

--- a/manager/catalog_manager.go
+++ b/manager/catalog_manager.go
@@ -20,6 +20,11 @@ import (
 
 type arrayFlags []string
 
+//ConfigFileFields stores catalogs
+type ConfigFileFields struct {
+	Catalogs []CatalogInput
+}
+
 //CatalogInput stores catalogs accepted from JSON file
 type CatalogInput struct {
 	Name    string
@@ -103,8 +108,8 @@ func SetEnv() {
 	catalogURL = commandLineURL
 
 	var catalogObject []CatalogInput
-	var catalogObjectJSON []CatalogInput
-	URLBranchMap = make(map[string]string)
+	var URLBranchMap = make(map[string]string)
+	var configFields = ConfigFileFields{}
 
 	//NEW CODE
 	// If catalog provided through command line
@@ -123,12 +128,12 @@ func SetEnv() {
 		if err != nil {
 			log.Debugf("JSON file does not exist, continuing for command line URLs")
 		} else {
-			err = json.Unmarshal(libraryContent, &catalogObjectJSON)
+			err = json.Unmarshal(libraryContent, &configFields)
 			if err != nil {
 				log.Errorf("JSON data format invalid, error : %v\n", err)
 			}
 
-			for _, value := range catalogObjectJSON {
+			for _, value := range configFields.Catalogs {
 				if (CatalogInput{} != value) {
 					catalogObject = append(catalogObject, value)
 					value.RepoURL = value.Name + "=" + value.RepoURL

--- a/repo.json
+++ b/repo.json
@@ -1,12 +1,14 @@
-[
-	{
-		"name":"qa-catalog",
-		"repoURL":"https://github.com/rancher/qa-catalog",
-		"branch":"master"
-	},
-	{
-		"name":"rancher-catalog",
-		"repoURL":"https://github.com/rancher/rancher-catalog",
-		"branch":"master"
-	}
-]
+{
+	"catalogs":[
+		{
+			"name":"qa-catalog",
+			"repoURL":"https://github.com/rancher/qa-catalog",
+			"branch":"master"
+		},
+		{
+			"name":"rancher-catalog",
+			"repoURL":"https://github.com/rancher/rancher-catalog",
+			"branch":"master"
+		}
+	]
+}


### PR DESCRIPTION
The configFile is now in the format of a JSON object with "catalogs" as a key, that has a JSON array of catalogs. Sample file provided is repo.json:
{
	"catalogs":[
		{
			"name":"qa-catalog",
			"repoURL":"https://github.com/rancher/qa-catalog",
			"branch":"master"
		},
		{
			"name":"rancher-catalog",
			"repoURL":"https://github.com/rancher/rancher-catalog",
			"branch":"master"
		}
	]
}