### PR TITLE
Adds 'labels' key for templateVersion

### DIFF
--- a/manager/catalog.go
+++ b/manager/catalog.go
@@ -294,7 +294,7 @@ func readRancherCompose(relativePath string, newTemplate *model.Template) error 
 	newTemplate.Version = RC[".catalog"].Version
 	newTemplate.MinimumRancherVersion = RC[".catalog"].MinimumRancherVersion
 	newTemplate.Output = RC[".catalog"].Output
-
+	newTemplate.Labels = RC[".catalog"].Labels
 	return nil
 }
 

--- a/model/rancher_compose.go
+++ b/model/rancher_compose.go
@@ -28,11 +28,12 @@ type Output struct {
 //RancherCompose holds the questions array
 type RancherCompose struct {
 	//rancher.RancherConfig	`yaml:",inline"`
-	Name                  string     `yaml:"name"`
-	UUID                  string     `yaml:"uuid"`
-	Description           string     `yaml:"description"`
-	Version               string     `yaml:"version"`
-	Questions             []Question `json:"questions" yaml:"questions,omitempty"`
-	MinimumRancherVersion string     `json:"minimumRancherVersion" yaml:"minimum_rancher_version,omitempty"`
-	Output                Output     `json:"output" yaml:"output,omitempty"`
+	Name                  string            `yaml:"name"`
+	UUID                  string            `yaml:"uuid"`
+	Description           string            `yaml:"description"`
+	Version               string            `yaml:"version"`
+	Questions             []Question        `json:"questions" yaml:"questions,omitempty"`
+	MinimumRancherVersion string            `json:"minimumRancherVersion" yaml:"minimum_rancher_version,omitempty"`
+	Output                Output            `json:"output" yaml:"output,omitempty"`
+	Labels                map[string]string `json:"labels" yaml:"labels,omitempty"`
 }

--- a/model/template.go
+++ b/model/template.go
@@ -20,12 +20,13 @@ type Template struct {
 	Path                          string            `json:"path"`
 	MinimumRancherVersion         string            `json:"minimumRancherVersion"`
 	TemplateVersionRancherVersion map[string]string
-	Maintainer                    string `json:"maintainer"`
-	License                       string `json:"license"`
-	ProjectURL                    string `json:"projectURL"`
-	ReadmeLink                    string `json:"readmeLink"`
-	Output                        Output `json:"output" yaml:"output,omitempty"`
-	TemplateBase                  string `json:"templateBase"`
+	Maintainer                    string            `json:"maintainer"`
+	License                       string            `json:"license"`
+	ProjectURL                    string            `json:"projectURL"`
+	ReadmeLink                    string            `json:"readmeLink"`
+	Output                        Output            `json:"output" yaml:"output,omitempty"`
+	TemplateBase                  string            `json:"templateBase"`
+	Labels                        map[string]string `json:"labels"`
 }
 
 //TemplateCollection holds a collection of templates


### PR DESCRIPTION
'labels' key is added to the templateVersion, which displays 'labels' provided in rancher-compose.yml