### PR TITLE
Remove log.fatal message

### DIFF
--- a/manager/catalog_manager.go
+++ b/manager/catalog_manager.go
@@ -214,7 +214,7 @@ func SetEnv() {
 		CatalogsCollection = UpdatedCatalogsCollection
 	} else {
 		err := "Halting Catalog service, Catalog git repo url not provided"
-		log.Fatal(err)
+		log.Info(err)
 		_ = fmt.Errorf(err)
 	}
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/5960
The `log.Fatal` message when all catalogs are disabled caused the catalog-service to stop. It has been changed to log.Info, so catalog-service doesn't stop, and works as earlier once catalog urls are provided again.