### PR TITLE
Read cache before git pull

### DIFF
--- a/manager/catalog.go
+++ b/manager/catalog.go
@@ -60,16 +60,16 @@ func (cat *Catalog) readCatalog() error {
 		repoURL = strings.TrimSpace(repoURL)
 		if repoURL == cat.URL {
 			log.Debugf("Catalog %v already exists with same repo url, pulling updates", cat.CatalogID)
-			err := cat.pullCatalog()
-			if err != nil {
-				log.Errorf("Git pull for Catalog %v failing with error: %v ", cat.CatalogID, err)
-			}
 			cat.metadata = make(map[string]model.Template)
 			//walk the catalog and read the metadata to the cache
 			filepath.Walk(cat.catalogRoot, cat.walkCatalog)
 			if ValidationMode {
 				log.Infof("Catalog loaded without errors")
 				os.Exit(0)
+			}
+			err := cat.pullCatalog()
+			if err != nil {
+				log.Errorf("Git pull for Catalog %v failing with error: %v ", cat.CatalogID, err)
 			}
 		} else {
 			//remove the existing repo

--- a/manager/catalog_manager.go
+++ b/manager/catalog_manager.go
@@ -53,8 +53,6 @@ var (
 	CatalogsCollection map[string]*Catalog
 	//UpdatedCatalogsCollection is the map storing updated template catalogs
 	UpdatedCatalogsCollection map[string]*Catalog
-	//CatalogReadyChannel signals if the catalog is cloned and loaded in memmory
-	CatalogReadyChannel = make(chan int, 1)
 
 	//PathToImage holds the mapping between a template path in the repo to its image name
 	PathToImage map[string]string
@@ -228,7 +226,6 @@ func Init() {
 
 	//start a background timer to pull from the Catalog periodically
 	startCatalogBackgroundPoll()
-	CatalogReadyChannel <- 1
 }
 
 func startCatalogBackgroundPoll() {

--- a/service/routes.go
+++ b/service/routes.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"strconv"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
@@ -19,19 +18,7 @@ type MuxWrapper struct {
 }
 
 func (httpWrapper *MuxWrapper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	select {
-	case <-manager.CatalogReadyChannel:
-		httpWrapper.IsReady = true
-	default:
-	}
-
-	if httpWrapper.IsReady {
-		//delegate to the mux router
-		httpWrapper.Router.ServeHTTP(w, r)
-	} else {
-		log.Debugf("Service Unavailable")
-		ReturnHTTPError(w, r, http.StatusServiceUnavailable, "Catalog Service is not yet available, please try again later")
-	}
+	httpWrapper.Router.ServeHTTP(w, r)
 }
 
 //ReturnHTTPError handles sending out CatalogError response


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/4903
https://github.com/rancher/rancher/issues/5352

The catalog-service waits till all catalogs are read from cache before it starts accepting requests. That results in a 503 "Service not available" error when the catalog-service is still being initialized (read from cache). This PR removes the wait on catalog-service being ready. It also reverses the order of loading catalogs into metadata by first reading from cache and then doing `git pull`. This is because when github is disabled, `git pull` takes time to fail and earlier no catalogs were displayed, where as we can now display the catalogs from cache as soon as the request to catalog-service is made.