### PR TITLE
Remove deleted catalogs from disk

### DIFF
--- a/manager/catalog_manager.go
+++ b/manager/catalog_manager.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
+	"path"
 	"strings"
 	"syscall"
 	"time"
@@ -150,6 +151,29 @@ func SetEnv() {
 
 	if *validate {
 		ValidationMode = true
+	} else {
+		//Code to delete non-embedded catalogs
+		setCatalogDirectories := make(map[string]bool)
+		for _, cat := range catalogURL {
+			catalog := strings.Split(cat, "=")[0]
+			setCatalogDirectories[catalog] = true
+		}
+		//get all subdirs under catalogRoot, if they are not part of catalogDirectories then rm -rf
+		clonedCatalogDirectories, _ := ioutil.ReadDir(CatalogRootDir)
+		log.Debugf("Removing deleted catalogs\n")
+		for _, dir := range clonedCatalogDirectories {
+			clonedCatalog := dir.Name()
+			if !setCatalogDirectories[clonedCatalog] {
+				noPurge := path.Join(CatalogRootDir, clonedCatalog, ".nopurge")
+				_, err := os.Stat(noPurge)
+				if os.IsNotExist(err) {
+					err = os.RemoveAll(path.Join(CatalogRootDir, clonedCatalog))
+					if err != nil {
+						log.Errorf("Error %v removing directory %s", err, clonedCatalog)
+					}
+				}
+			}
+		}
 	}
 
 	if *logFile != "" {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/6072

This PR removes the catalogs deleted in the UI from the disk. In order to keep the embedded infra, library and community catalogs, they need to have a `.nopurge` file in them.