### PR TITLE
Separate git pull from readCatalog

### DIFF
--- a/manager/catalog.go
+++ b/manager/catalog.go
@@ -68,10 +68,6 @@ func (cat *Catalog) readCatalog() error {
 				log.Infof("Catalog loaded without errors")
 				os.Exit(0)
 			}
-			err := cat.pullCatalog()
-			if err != nil {
-				log.Errorf("Git pull for Catalog %v failing with error: %v ", cat.CatalogID, err)
-			}
 		} else {
 			//remove the existing repo
 			err := os.RemoveAll(CatalogRootDir + cat.CatalogID)

--- a/manager/catalog_manager.go
+++ b/manager/catalog_manager.go
@@ -224,6 +224,10 @@ func Init() {
 		catalog.readCatalog()
 	}
 
+	for _, catalog := range CatalogsCollection {
+		catalog.pullCatalog()
+	}
+
 	//start a background timer to pull from the Catalog periodically
 	startCatalogBackgroundPoll()
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/5352
https://github.com/rancher/rancher/issues/4903

This PR separates `git pull` from `readCatalog` function. The first for-loop in `Init()` reads all catalogs from cache and the second for-loop calls `pullCatalog` on all catalogs