### PR TITLE
Remove refreshCatalog call from GetNewTemplateVersions

### DIFF
--- a/manager/catalog_manager.go
+++ b/manager/catalog_manager.go
@@ -369,10 +369,7 @@ func GetNewTemplateVersions(path string) (model.Template, bool) {
 	parentPath := tokens[1]
 	cVersion := tokens[2]
 
-	//refresh the catalog and sync any new changes
-
 	cat := CatalogsCollection[catalogID]
-	cat.refreshCatalog()
 
 	templateName, templateID := ExtractTemplatePrefixAndName(parentPath)
 	rancherComposePathCurrent := CatalogRootDir + catalogID + "/" + templateName + "/" + templateID + "/" + cVersion


### PR DESCRIPTION
`GetNewTemplateVersions` is one of the functions called for route `/v1-catalog/templates/{catalog_template_version_Id}`. This function has a call to refreshCatalog that was not needed here since the `startCatalogBackgroundPoll` function will refresh on fixed interval, and also changing the catalog entries will cause a refresh. This PR removes the call to `refreshCatalog` from `GetNewTemplateVersions`