### PR TITLE
Support labeled options for enum fields in catalog templates

### DIFF
--- a/model/rancher_compose.go
+++ b/model/rancher_compose.go
@@ -4,20 +4,21 @@ package model
 
 //Question holds the properties of a question present in rancher-compose.yml file
 type Question struct {
-	Variable     string   `json:"variable" yaml:"variable,omitempty"`
-	Label        string   `json:"label" yaml:"label,omitempty"`
-	Description  string   `json:"description" yaml:"description,omitempty"`
-	Type         string   `json:"type" yaml:"type,omitempty"`
-	Required     bool     `json:"required" yaml:"required,omitempty"`
-	Default      string   `json:"default" yaml:"default,omitempty"`
-	Group        string   `json:"group" yaml:"group,omitempty"`
-	MinLength    int      `json:"minLength" yaml:"min_length,omitempty"`
-	MaxLength    int      `json:"maxLength" yaml:"max_length,omitempty"`
-	Min          int      `json:"min" yaml:"min,omitempty"`
-	Max          int      `json:"max" yaml:"max,omitempty"`
-	Options      []string `json:"options" yaml:"options,omitempty"`
-	ValidChars   string   `json:"validChars" yaml:"valid_chars,omitempty"`
-	InvalidChars string   `json:"invalidChars" yaml:"invalid_chars,omitempty"`
+	Variable       string            `json:"variable" yaml:"variable,omitempty"`
+	Label          string            `json:"label" yaml:"label,omitempty"`
+	Description    string            `json:"description" yaml:"description,omitempty"`
+	Type           string            `json:"type" yaml:"type,omitempty"`
+	Required       bool              `json:"required" yaml:"required,omitempty"`
+	Default        string            `json:"default" yaml:"default,omitempty"`
+	Group          string            `json:"group" yaml:"group,omitempty"`
+	MinLength      int               `json:"minLength" yaml:"min_length,omitempty"`
+	MaxLength      int               `json:"maxLength" yaml:"max_length,omitempty"`
+	Min            int               `json:"min" yaml:"min,omitempty"`
+	Max            int               `json:"max" yaml:"max,omitempty"`
+	Options        []string          `json:"options" yaml:"options,omitempty"`
+	LabeledOptions map[string]string `json:"labeledOptions" yaml:"labeled_options,omitempty"`
+	ValidChars     string            `json:"validChars" yaml:"valid_chars,omitempty"`
+	InvalidChars   string            `json:"invalidChars" yaml:"invalid_chars,omitempty"`
 }
 
 //Output holds the outputs of the template


### PR DESCRIPTION
This is needed to improve user experience of catalog entry configuration. 

For example, in Rancher v1.3 when starting Kubernetes system stack, the user will be asked if they want to use Rancher DNS or KubeDNS as the DNS service for their Kubernetes cluster. 

It'd be nice to present the user with the choice between "Rancher DNS" and "KubeDNS" instead of "169.254.169.250" and "10.43.0.10". 