### PR TITLE
WIP: Send etags for catalog icon

### DIFF
--- a/manager/catalog.go
+++ b/manager/catalog.go
@@ -43,6 +43,7 @@ type Catalog struct {
 	refreshReqChannel *chan int
 	metadata          map[string]model.Template
 	URLBranch         string `json:"branch"`
+	Etags             string
 }
 
 func (cat *Catalog) getID() string {
@@ -225,6 +226,14 @@ func (cat *Catalog) pullCatalog() error {
 	}
 	cat.LastUpdated = time.Now().Format(time.RFC3339)
 	cat.State = "active"
+
+	etagGenerateCmd := exec.Command("git", "-C", cat.catalogRoot, "rev-parse", "HEAD")
+	out, err = etagGenerateCmd.Output()
+	if err != nil {
+		log.Errorf("Failed to get commit of %s, error: %v", cat.URL, err.Error())
+		return err
+	}
+	cat.Etags = string(out)
 	return nil
 }
 

--- a/manager/catalog_manager.go
+++ b/manager/catalog_manager.go
@@ -313,6 +313,7 @@ func GetCatalog(catalogID string) (Catalog, bool) {
 		catalog.Message = cat.Message
 		catalog.LastUpdated = cat.LastUpdated
 		catalog.CatalogLink = cat.CatalogID + "/templates"
+		catalog.Etags = cat.Etags
 	}
 	return catalog, ok
 }

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -498,6 +498,18 @@ func loadFile(catalogID string, templateID string, versionID string, fileNameMap
 		fileID = fileNameMap[catalogID+"/"+templateID]
 		path = "DATA/" + catalogID + "/" + prefix + "/" + templateName + "/" + fileID
 	}
+
+	if strings.EqualFold("image", r.URL.RawQuery) {
+		cat, _ := manager.GetCatalog(catalogID)
+		w.Header().Set("Etag", cat.Etags)
+
+		if match := r.Header.Get("If-None-Match"); match != "" {
+			if strings.Contains(match, cat.Etags) {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+		}
+	}
 	log.Debugf("Request to load file: %s", path)
 	http.ServeFile(w, r, path)
 }


### PR DESCRIPTION
This PR adds logic to send etags based on the catalog's latest commit number. The etags are checked to serve updated Catalog Icons.
https://github.com/rancher/rancher/issues/6071