### PR TITLE
Catalog background poll

### DIFF
--- a/integration/core/test_api.py
+++ b/integration/core/test_api.py
@@ -276,42 +276,39 @@ def test_v2_upgrade(client):
 
 
 def test_upgrade_filters(client):
-    templates = client.list_template(catalogId='rancher')
+    templates = client.list_template(catalogId='qa-catalog')
     if len(templates) > 0:
         for i in range(len(templates)):
-            if templates[i].name == 'Kubernetes' \
-                    and templates[i].templateBase == 'infra':
+            if templates[i].id == unicode('qa-catalog:many-versions'):
                 versionUrlsMap = templates[i].versionLinks
-        assert len(versionUrlsMap) == 12
+        assert len(versionUrlsMap) == 15
 
-    filter = "v1.2.0-pre4-rc10"
-    templates = client.list_template(catalogId='rancher',
+    filter = "v2.2.0"
+    templates = client.list_template(catalogId='qa-catalog',
                                      maximumRancherVersion_gte=filter,
                                      minimumRancherVersion_lte=filter)
     if len(templates) > 0:
         for i in range(len(templates)):
-            if templates[i].name == 'Kubernetes' \
-                    and templates[i].templateBase == 'infra':
+            if templates[i].id == unicode('qa-catalog:many-versions'):
                 versionUrlsMap = templates[i].versionLinks
         assert len(versionUrlsMap) == 1
-        assert "v1.4.6-rancher1" in versionUrlsMap
+        assert "1.0.14" in versionUrlsMap
 
-    templates = client.list_template(catalogId='rancher')
+    templates = client.list_template(catalogId='qa-catalog')
     if len(templates) > 0:
         for i in range(len(templates)):
-            if templates[i].name == 'Kubernetes' \
-                    and templates[i].templateBase == 'infra':
+            if templates[i].id == unicode('qa-catalog:many-versions'):
                 versionUrlsMap = templates[i].versionLinks
         for key in versionUrlsMap.keys():
-            if key == "v1.2.4-rancher10":
+            if key == "1.0.12":
                 url_to_try = versionUrlsMap[key]
                 response = requests. \
                     get(url_to_try +
-                        '?minimumRancherVersion_lte=v1.2.0-pre4-rc10&'
-                        'maximumRancherVersion_gte=v1.2.0-pre4-rc10')
+                        '?minimumRancherVersion_lte=v2.2.0&'
+                        'maximumRancherVersion_gte=v2.2.0')
                 assert response is not 404
                 response_json = response.json()
                 upgradeUrls = response_json. \
                     get(unicode('upgradeVersionLinks'))
                 assert len(upgradeUrls) == 1
-                assert "v1.4.6-rancher1" in upgradeUrls
+                assert "1.0.14" in upgradeUrls

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ func main() {
 	manager.GetCommandLine()
 
 	go manager.Init()
+	manager.StartCatalogBackgroundPoll()
 	manager.WatchSignals()
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *manager.Port), &handler))
 }

--- a/manager/catalog.go
+++ b/manager/catalog.go
@@ -238,7 +238,7 @@ func (cat *Catalog) refreshCatalog() {
 			cat.metadata = make(map[string]model.Template)
 			filepath.Walk(cat.catalogRoot, cat.walkCatalog)
 		} else {
-			log.Debugf("Will not refresh the catalog since Pull Catalog faced error: %v", err)
+			log.Infof("Will not refresh the catalog since Pull Catalog faced error: %v", err)
 		}
 		<-*cat.refreshReqChannel
 	default:

--- a/manager/catalog_manager.go
+++ b/manager/catalog_manager.go
@@ -251,12 +251,10 @@ func Init() {
 	for _, catalog := range CatalogsCollection {
 		catalog.pullCatalog()
 	}
-
-	//start a background timer to pull from the Catalog periodically
-	startCatalogBackgroundPoll()
 }
 
-func startCatalogBackgroundPoll() {
+//StartCatalogBackgroundPoll starts a background timer to pull from the Catalog periodically
+func StartCatalogBackgroundPoll() {
 	ticker := time.NewTicker(time.Duration(*refreshInterval) * time.Second)
 	go func() {
 		for t := range ticker.C {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/7230

`startCatalogBackgroundPoll` was being called twice, once when catalog-service is launched and once when catalog reload was done from UI. This PR calls it only once from main.go
Because it was called twice, the default case was invoked in refreshCatalog and the "Refresh for catalog is already in progress, skipping" message was getting repeated.